### PR TITLE
Use GIT dependencies for out-of-repository crates instead of paths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ path = "src/bin/matroska_info.rs"
 [dependencies]
 nom = { git = "https://github.com/Geal/nom", branch="result" }
 cookie-factory = "^0.2"
-av-data = { version = "0.1.0", path = "../rust-av/data" }
-av-format = { version = "0.1.0", path = "../rust-av/format" }
+av-data = { version = "0.1.0", git = "https://github.com/rust-av/rust-av" }
+av-format = { version = "0.1.0", git = "https://github.com/rust-av/rust-av" }
 circular = { git = "https://github.com/sozu-proxy/circular" }
 
 [dev-dependencies]


### PR DESCRIPTION
https://github.com/rust-av/rust-av/issues/55