### PR TITLE
Fix dependency graph prior to Rust 2018 update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,10 @@ name = "matroska"
 path = "src/lib.rs"
 
 [dependencies]
-nom = "^4.0"
-cookie-factory = "^0.2"
-av-data = { git = "https://github.com/rust-av/rust-av" }
-av-format = { git = "https://github.com/rust-av/rust-av" }
+nom = "4.0"
+cookie-factory = "0.2"
+av-data = "0.1"
+av-format = "0.1"
 circular = "0.2"
 log = "0.4"
 


### PR DESCRIPTION
This PR fixes dependency resolution with the toolchain packaged alongside newer versions of Rust (and probably has something to do with my changes in the rust-av repo). I'll update code practices and style in a separate PR, but if this passes CI it should be a rather minor upgrade to go along with my other update PRs.