### PR TITLE
Step1: Update to Rust 2018 Edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 authors = ["Luca Barbato <lu_zero@gentoo.org>"]
 readme = "README.md"
 license = "MIT"
+edition = "2018"
 
 [lib]
 name = "matroska"

--- a/examples/matroska_remux.rs
+++ b/examples/matroska_remux.rs
@@ -4,8 +4,6 @@ extern crate matroska;
 extern crate nom;
 
 extern crate pretty_env_logger;
-#[macro_use]
-extern crate log;
 
 use av_format::buffer::AccReader;
 use av_format::demuxer::{self, Event};

--- a/examples/matroska_remux.rs
+++ b/examples/matroska_remux.rs
@@ -1,19 +1,10 @@
-extern crate av_data;
-extern crate av_format;
-extern crate matroska;
-extern crate nom;
-
-extern crate pretty_env_logger;
-
-use av_format::buffer::AccReader;
-use av_format::demuxer::{self, Event};
-use av_format::muxer;
-use std::fs::File;
-use std::io::Cursor;
-use std::sync::Arc;
-
-use matroska::demuxer::MKV_DESC;
-use matroska::muxer::MkvMuxer;
+use av_format::{
+    buffer::AccReader,
+    demuxer::{self, Event},
+    muxer,
+};
+use matroska::{demuxer::MKV_DESC, muxer::MkvMuxer};
+use std::{fs::File, io::Cursor, sync::Arc};
 
 fn main() {
     pretty_env_logger::init();

--- a/src/demuxer.rs
+++ b/src/demuxer.rs
@@ -10,6 +10,7 @@ use av_format::stream::Stream;
 use crate::rational::Rational64;
 use std::collections::VecDeque;
 use std::io::SeekFrom;
+use log::{trace, debug, error};
 
 use crate::ebml::{ebml_header, EBMLHeader};
 use crate::elements::{
@@ -331,6 +332,7 @@ mod tests {
     use av_format::demuxer::Context;
     use nom::Offset;
     use std::io::Cursor;
+    use log::info;
 
     const webm: &'static [u8] = include_bytes!("../assets/bbb-vp9-opus.webm");
 

--- a/src/demuxer.rs
+++ b/src/demuxer.rs
@@ -107,7 +107,7 @@ impl MkvDemuxer {
 use nom::Needed;
 
 impl Demuxer for MkvDemuxer {
-    fn read_headers(&mut self, buf: &Box<Buffered>, info: &mut GlobalInfo) -> Result<SeekFrom> {
+    fn read_headers(&mut self, buf: &Box<dyn Buffered>, info: &mut GlobalInfo) -> Result<SeekFrom> {
         match self.parse_until_tracks(buf.data()) {
             Ok((i, _)) => {
                 info.duration = self
@@ -137,7 +137,7 @@ impl Demuxer for MkvDemuxer {
         }
     }
 
-    fn read_event(&mut self, buf: &Box<Buffered>) -> Result<(SeekFrom, Event)> {
+    fn read_event(&mut self, buf: &Box<dyn Buffered>) -> Result<(SeekFrom, Event)> {
         if let Some(event) = self.queue.pop_front() {
             Ok((SeekFrom::Current(0), event))
         } else {
@@ -299,7 +299,7 @@ struct Des {
 }
 
 impl Descriptor for Des {
-    fn create(&self) -> Box<Demuxer> {
+    fn create(&self) -> Box<dyn Demuxer> {
         Box::new(MkvDemuxer::new())
     }
     fn describe<'a>(&'a self) -> &'a Descr {
@@ -313,7 +313,7 @@ impl Descriptor for Des {
     }
 }
 
-pub const MKV_DESC: &Descriptor = &Des {
+pub const MKV_DESC: &dyn Descriptor = &Des {
     d: Descr {
         name: "matroska",
         demuxer: "mkv",

--- a/src/demuxer.rs
+++ b/src/demuxer.rs
@@ -1,23 +1,22 @@
-use av_data::packet::Packet;
-use av_data::params::*;
-use av_data::timeinfo::TimeInfo;
-use av_format::buffer::Buffered;
-use av_format::common::GlobalInfo;
-use av_format::demuxer::{Demuxer, Event};
-use av_format::demuxer::{Descr, Descriptor};
-use av_format::error::*;
-use av_format::stream::Stream;
-use crate::rational::Rational64;
-use std::collections::VecDeque;
-use std::io::SeekFrom;
-use log::{trace, debug, error};
-
-use crate::ebml::{ebml_header, EBMLHeader};
-use crate::elements::{
-    segment, segment_element, simple_block, Cluster, Info, SeekHead, SegmentElement, TrackEntry,
-    Tracks,
+use crate::{
+    ebml::{ebml_header, EBMLHeader},
+    elements::{
+        segment, segment_element, simple_block, Cluster, Info, SeekHead, SegmentElement,
+        TrackEntry, Tracks,
+    },
+    rational::Rational64,
 };
+use av_data::{packet::Packet, params::*, timeinfo::TimeInfo};
+use av_format::{
+    buffer::Buffered,
+    common::GlobalInfo,
+    demuxer::{Demuxer, Descr, Descriptor, Event},
+    error::*,
+    stream::Stream,
+};
+use log::{debug, error, trace};
 use nom::{self, Err, IResult, Offset};
+use std::{collections::VecDeque, io::SeekFrom};
 
 #[derive(Debug, Clone)]
 pub struct MkvDemuxer {
@@ -328,11 +327,10 @@ pub const MKV_DESC: &dyn Descriptor = &Des {
 #[allow(non_upper_case_globals)]
 mod tests {
     use super::*;
-    use av_format::buffer::*;
-    use av_format::demuxer::Context;
+    use av_format::{buffer::*, demuxer::Context};
+    use log::info;
     use nom::Offset;
     use std::io::Cursor;
-    use log::info;
 
     const webm: &'static [u8] = include_bytes!("../assets/bbb-vp9-opus.webm");
 

--- a/src/demuxer.rs
+++ b/src/demuxer.rs
@@ -7,12 +7,12 @@ use av_format::demuxer::{Demuxer, Event};
 use av_format::demuxer::{Descr, Descriptor};
 use av_format::error::*;
 use av_format::stream::Stream;
-use rational::Rational64;
+use crate::rational::Rational64;
 use std::collections::VecDeque;
 use std::io::SeekFrom;
 
-use ebml::{ebml_header, EBMLHeader};
-use elements::{
+use crate::ebml::{ebml_header, EBMLHeader};
+use crate::elements::{
     segment, segment_element, simple_block, Cluster, Info, SeekHead, SegmentElement, TrackEntry,
     Tracks,
 };

--- a/src/ebml.rs
+++ b/src/ebml.rs
@@ -1,4 +1,5 @@
 use nom::{Err, ErrorKind, IResult, Needed};
+use log::trace;
 
 /*
 struct Document {
@@ -362,6 +363,7 @@ named!(pub ebml_header<EBMLHeader>,
 mod tests {
     use super::*;
     use nom::{HexDisplay, Offset};
+    use log::trace;
 
     const single_stream: &'static [u8] = include_bytes!("../assets/single_stream.mkv");
     const webm: &'static [u8] = include_bytes!("../assets/big-buck-bunny_trailer.webm");

--- a/src/ebml.rs
+++ b/src/ebml.rs
@@ -1,5 +1,5 @@
-use nom::{Err, ErrorKind, IResult, Needed};
 use log::trace;
+use nom::{Err, ErrorKind, IResult, Needed};
 
 /*
 struct Document {
@@ -49,7 +49,13 @@ pub fn vint(input: &[u8]) -> IResult<&[u8], u64> {
 
     let mut val = (v ^ (1 << (7 - len))) as u64;
 
-    trace!("vint {:08b} {:08b} {:08b} {}", val, v, (1 << (8 - len)), len);
+    trace!(
+        "vint {:08b} {:08b} {:08b} {}",
+        val,
+        v,
+        (1 << (8 - len)),
+        len
+    );
 
     for i in 0..len as usize {
         val = (val << 8) | input[i + 1] as u64;
@@ -362,8 +368,8 @@ named!(pub ebml_header<EBMLHeader>,
 #[allow(non_upper_case_globals)]
 mod tests {
     use super::*;
-    use nom::{HexDisplay, Offset};
     use log::trace;
+    use nom::{HexDisplay, Offset};
 
     const single_stream: &'static [u8] = include_bytes!("../assets/single_stream.mkv");
     const webm: &'static [u8] = include_bytes!("../assets/big-buck-bunny_trailer.webm");

--- a/src/ebml.rs
+++ b/src/ebml.rs
@@ -151,12 +151,12 @@ fn parse_str(input: &[u8], size: u64) -> IResult<&[u8], ElementData> {
 pub fn parse_str_data(input: &[u8], size: u64) -> IResult<&[u8], String> {
     do_parse!(
         input,
-        s: take_s!(size as usize) >> (String::from_utf8(s.to_owned()).unwrap()) //FIXME: maybe do not unwrap here
+        s: take!(size as usize) >> (String::from_utf8(s.to_owned()).unwrap()) //FIXME: maybe do not unwrap here
     )
 }
 
 pub fn parse_binary_data(input: &[u8], size: u64) -> IResult<&[u8], Vec<u8>> {
-    do_parse!(input, s: take_s!(size as usize) >> (s.to_owned()))
+    do_parse!(input, s: take!(size as usize) >> (s.to_owned()))
 }
 
 //FIXME: handle default values

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -985,6 +985,7 @@ mod tests {
     use super::*;
     use nom::{HexDisplay, Offset};
     use std::cmp::min;
+    use log::debug;
 
     const mkv: &'static [u8] = include_bytes!("../assets/single_stream.mkv");
     const webm: &'static [u8] = include_bytes!("../assets/big-buck-bunny_trailer.webm");

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -1,5 +1,5 @@
 #![allow(unused_assignments)]
-use ebml::{vid, vint};
+use crate::ebml::{vid, vint};
 use nom::{be_i16, be_u8, IResult};
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -983,9 +983,9 @@ pub struct Tags {}
 #[allow(non_upper_case_globals)]
 mod tests {
     use super::*;
+    use log::debug;
     use nom::{HexDisplay, Offset};
     use std::cmp::min;
-    use log::debug;
 
     const mkv: &'static [u8] = include_bytes!("../assets/single_stream.mkv");
     const webm: &'static [u8] = include_bytes!("../assets/big-buck-bunny_trailer.webm");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,9 +4,6 @@ extern crate nom;
 #[macro_use]
 extern crate cookie_factory;
 
-#[macro_use]
-extern crate log;
-
 extern crate av_data;
 extern crate av_format;
 

--- a/src/muxer.rs
+++ b/src/muxer.rs
@@ -6,6 +6,7 @@ use av_format::error::*;
 use av_format::muxer::*;
 use av_format::stream::Stream;
 use std::sync::Arc;
+use log::error;
 
 use cookie_factory::GenError;
 use crate::ebml::EBMLHeader;

--- a/src/muxer.rs
+++ b/src/muxer.rs
@@ -8,12 +8,12 @@ use av_format::stream::Stream;
 use std::sync::Arc;
 
 use cookie_factory::GenError;
-use ebml::EBMLHeader;
-use elements::{
+use crate::ebml::EBMLHeader;
+use crate::elements::{
     Audio, Cluster, Info, Lacing, Seek, SeekHead, SimpleBlock, TrackEntry, Tracks, Video,
 };
-use serializer::ebml::{gen_ebml_header, EbmlSize};
-use serializer::elements::{
+use crate::serializer::ebml::{gen_ebml_header, EbmlSize};
+use crate::serializer::elements::{
     gen_cluster, gen_info, gen_seek_head, gen_segment_header_unknown_size, gen_simple_block_header,
     gen_tracks,
 };
@@ -172,7 +172,7 @@ impl MkvMuxer {
         if let Some(ref info) = self.info.as_ref() {
             let mut origin = (&buf).as_ptr() as usize;
             let mut needed = 0usize;
-            let mut offset;
+            let offset;
             loop {
                 if needed > 0 {
                     let len = needed + buf.len();
@@ -203,7 +203,7 @@ impl MkvMuxer {
         if let Some(ref tracks) = self.tracks.as_ref() {
             let mut origin = (&buf).as_ptr() as usize;
             let mut needed = 0usize;
-            let mut offset;
+            let offset;
             loop {
                 if needed > 0 {
                     let len = needed + buf.len();

--- a/src/muxer.rs
+++ b/src/muxer.rs
@@ -1,23 +1,22 @@
-use av_data::packet::Packet;
-use av_data::params::MediaKind;
-use av_data::value::Value;
-use av_format::common::GlobalInfo;
-use av_format::error::*;
-use av_format::muxer::*;
-use av_format::stream::Stream;
-use std::sync::Arc;
+use av_data::{packet::Packet, params::MediaKind, value::Value};
+use av_format::{common::GlobalInfo, error::*, muxer::*, stream::Stream};
 use log::error;
+use std::sync::Arc;
 
+use crate::{
+    ebml::EBMLHeader,
+    elements::{
+        Audio, Cluster, Info, Lacing, Seek, SeekHead, SimpleBlock, TrackEntry, Tracks, Video,
+    },
+    serializer::{
+        ebml::{gen_ebml_header, EbmlSize},
+        elements::{
+            gen_cluster, gen_info, gen_seek_head, gen_segment_header_unknown_size,
+            gen_simple_block_header, gen_tracks,
+        },
+    },
+};
 use cookie_factory::GenError;
-use crate::ebml::EBMLHeader;
-use crate::elements::{
-    Audio, Cluster, Info, Lacing, Seek, SeekHead, SimpleBlock, TrackEntry, Tracks, Video,
-};
-use crate::serializer::ebml::{gen_ebml_header, EbmlSize};
-use crate::serializer::elements::{
-    gen_cluster, gen_info, gen_seek_head, gen_segment_header_unknown_size, gen_simple_block_header,
-    gen_tracks,
-};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct MkvMuxer {
@@ -476,11 +475,11 @@ pub fn gen_mkv_prefix<'a>(
 
 pub fn stream_to_track(s: &Stream) -> TrackEntry {
     /*let track_type = match s.params.kind {
-    Some(MediaKind::Video(_)) => 0x1,
-    Some(MediaKind::Audio(_)) => 0x2,
-    _                         => 0,
-  };
-  */
+      Some(MediaKind::Video(_)) => 0x1,
+      Some(MediaKind::Audio(_)) => 0x2,
+      _                         => 0,
+    };
+    */
 
     let codec_id = match s.params.codec_id.as_ref().map(|s| s.as_str()) {
         Some("opus") => String::from("A_OPUS"),

--- a/src/permutation.rs
+++ b/src/permutation.rs
@@ -15,7 +15,7 @@ macro_rules! permutation_opt (
 
         let void_res = $crate::ebml::skip_void(input);
         if let Ok((i,_)) = void_res {
-          trace!("skipping void element");
+          log::trace!("skipping void element");
           input = i;
           continue;
         }
@@ -32,7 +32,7 @@ macro_rules! permutation_opt (
       if let Some(unwrapped_res) = permutation_opt_unwrap!(0, (), res, $($rest)*) {
         Ok((input, unwrapped_res))
       } else if let ::std::option::Option::Some(need) = needed {
-        trace!("needed: {:?}", need);
+        log::trace!("needed: {:?}", need);
         Err(::nom::Err::convert(need))
       } else if let ::std::option::Option::Some(e) = permutation_error {
         Err(::nom::Err::Error(e))

--- a/src/permutation.rs
+++ b/src/permutation.rs
@@ -500,11 +500,11 @@ mod tests {
         let g = &b"hiabcdm"[..];
         assert_eq!(perm(g), Ok((&b"m"[..], expected3)));
         /*
-    let d = &b"efgxyzabcdefghi"[..];
-    assert_eq!(perm(d), Error(error_position!(&b"xyzabcdefghi"[..], ErrorKind::Permutation)));
+            let d = &b"efgxyzabcdefghi"[..];
+            assert_eq!(perm(d), Error(error_position!(&b"xyzabcdefghi"[..], ErrorKind::Permutation)));
 
-    let e = &b"efgabc"[..];
-    assert_eq!(perm(e), Incomplete(Needed::Size(7)));
-*/
+            let e = &b"efgabc"[..];
+            assert_eq!(perm(e), Incomplete(Needed::Size(7)));
+        */
     }
 }

--- a/src/serializer/ebml.rs
+++ b/src/serializer/ebml.rs
@@ -1,5 +1,5 @@
-use cookie_factory::*;
 use crate::ebml::EBMLHeader;
+use cookie_factory::*;
 use nom::AsBytes;
 
 pub fn vint_size(i: u64) -> u8 {
@@ -541,8 +541,8 @@ impl EbmlSize for Vec<u64> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nom::*;
     use log::info;
+    use nom::*;
 
     fn test_vint_serializer(i: u64) -> bool {
         info!("testing for {}", i);

--- a/src/serializer/ebml.rs
+++ b/src/serializer/ebml.rs
@@ -407,7 +407,7 @@ macro_rules! gen_dbg (
         let sl = unsafe {
           from_raw_parts_mut(p as *mut u8, len)
         };
-        trace!("gen_dbg {}->{}: {}:\n{}", idx, index, stringify!($submac!($($args)*)), (&sl[idx..index]).to_hex(16));
+        log::trace!("gen_dbg {}->{}: {}:\n{}", idx, index, stringify!($submac!($($args)*)), (&sl[idx..index]).to_hex(16));
         Ok((sl, index))
       },
       Err(e) => Err(e),
@@ -542,6 +542,7 @@ impl EbmlSize for Vec<u64> {
 mod tests {
     use super::*;
     use nom::*;
+    use log::info;
 
     fn test_vint_serializer(i: u64) -> bool {
         info!("testing for {}", i);

--- a/src/serializer/ebml.rs
+++ b/src/serializer/ebml.rs
@@ -1,5 +1,5 @@
 use cookie_factory::*;
-use ebml::EBMLHeader;
+use crate::ebml::EBMLHeader;
 use nom::AsBytes;
 
 pub fn vint_size(i: u64) -> u8 {
@@ -300,7 +300,7 @@ macro_rules! gen_ebml_uint (
 #[macro_export]
 macro_rules! gen_ebml_int (
   (($i:expr, $idx:expr), $id:expr, $num:expr, $expected_size:expr) => ({
-    use serializer::ebml::gen_int;
+    use crate::serializer::ebml::gen_int;
     let needed_bytes = vint_size($expected_size as u64);
 
     do_gen!(($i, $idx),
@@ -553,7 +553,7 @@ mod tests {
         }
         info!("{}", (&data[..]).to_hex(16));
 
-        let parse_res = ::ebml::vint(&data[..]);
+        let parse_res = crate::ebml::vint(&data[..]);
         info!("parse_res: {:?}", parse_res);
         match parse_res {
             Ok((_rest, o)) => {
@@ -589,7 +589,7 @@ mod tests {
         }
         info!("{}", (&data[..]).to_hex(16));
 
-        let parse_res = ::ebml::vid(&data[..]);
+        let parse_res = crate::ebml::vid(&data[..]);
         info!("parse_res: {:?}", parse_res);
         match parse_res {
             Ok((_rest, o)) => {
@@ -696,7 +696,7 @@ mod tests {
         }
 
         info!("{}", (&data[..]).to_hex(16));
-        let parse_res = ::ebml::ebml_header(&data[..]);
+        let parse_res = crate::ebml::ebml_header(&data[..]);
         info!("parse_res: {:?}", parse_res);
         match parse_res {
           Ok((_rest, h)) => {

--- a/src/serializer/elements.rs
+++ b/src/serializer/elements.rs
@@ -1,11 +1,11 @@
-use crate::serializer::ebml::{gen_uint, gen_vid, gen_vint, vint_size};
-use cookie_factory::*;
-use crate::elements::SilentTracks;
-use crate::elements::{
-    Audio, Cluster, Colour, Info, Lacing, MasteringMetadata, Projection, Seek, SeekHead,
-    SimpleBlock, TrackEntry, Tracks, Video,
+use crate::{
+    elements::{
+        Audio, Cluster, Colour, Info, Lacing, MasteringMetadata, Projection, Seek, SeekHead,
+        SilentTracks, SimpleBlock, TrackEntry, Tracks, Video,
+    },
+    serializer::ebml::{gen_f64, gen_f64_ref, gen_uint, gen_vid, gen_vint, vint_size, EbmlSize},
 };
-use crate::serializer::ebml::{gen_f64, gen_f64_ref, EbmlSize};
+use cookie_factory::*;
 
 pub fn seek_size(s: &Seek) -> u8 {
     // byte size of id (vid+size)+ data and position vid+size+int
@@ -623,12 +623,12 @@ pub fn gen_xiph_laced_frames<'a>(
     }
 
     /*
-  let sizes: Vec<usize> = frames.iter().map(|frame| frame.len()).collect();
-  do_gen!(input,
-    gen_be_u8!((frames.len() - 1) as u8) >>
+    let sizes: Vec<usize> = frames.iter().map(|frame| frame.len()).collect();
+    do_gen!(input,
+      gen_be_u8!((frames.len() - 1) as u8) >>
 
-  )
-  */
+    )
+    */
     Err(GenError::NotYetImplemented)
 }
 
@@ -680,9 +680,9 @@ pub fn gen_block_group<'a>(input: (&'a mut [u8], usize),
 mod tests {
     use super::*;
     use crate::elements::SegmentElement;
+    use log::trace;
     use nom::*;
     use std::iter::repeat;
-    use log::trace;
 
     fn test_seek_head_serializer(seeks: Vec<(u64, Vec<u8>)>) -> bool {
         trace!("testing for {:?}", seeks);
@@ -720,7 +720,8 @@ mod tests {
                 .map(|(position, id)| Seek {
                     id: id,
                     position: position,
-                }).collect(),
+                })
+                .collect(),
         };
 
         let ser_res = {
@@ -731,9 +732,9 @@ mod tests {
                 trace!("should fail: {:?}", should_fail);
                 return should_fail;
                 /*if should_fail {
-          trace!("should fail");
-          return true;
-        }*/
+                  trace!("should fail");
+                  return true;
+                }*/
             }
         };
 

--- a/src/serializer/elements.rs
+++ b/src/serializer/elements.rs
@@ -1,11 +1,11 @@
-use super::ebml::{gen_uint, gen_vid, gen_vint, vint_size};
+use crate::serializer::ebml::{gen_uint, gen_vid, gen_vint, vint_size};
 use cookie_factory::*;
-use elements::SilentTracks;
-use elements::{
+use crate::elements::SilentTracks;
+use crate::elements::{
     Audio, Cluster, Colour, Info, Lacing, MasteringMetadata, Projection, Seek, SeekHead,
     SimpleBlock, TrackEntry, Tracks, Video,
 };
-use serializer::ebml::{gen_f64, gen_f64_ref, EbmlSize};
+use crate::serializer::ebml::{gen_f64, gen_f64_ref, EbmlSize};
 
 pub fn seek_size(s: &Seek) -> u8 {
     // byte size of id (vid+size)+ data and position vid+size+int
@@ -679,7 +679,7 @@ pub fn gen_block_group<'a>(input: (&'a mut [u8], usize),
 #[cfg(test)]
 mod tests {
     use super::*;
-    use elements::SegmentElement;
+    use crate::elements::SegmentElement;
     use nom::*;
     use std::iter::repeat;
 
@@ -738,7 +738,7 @@ mod tests {
 
         trace!("ser_res: {:?}", ser_res);
 
-        let parse_res = ::elements::segment_element(&data[..]);
+        let parse_res = crate::elements::segment_element(&data[..]);
         trace!("parse_res: {:?}", parse_res);
         match parse_res {
             Ok((_rest, SegmentElement::SeekHead(o))) => {

--- a/src/serializer/elements.rs
+++ b/src/serializer/elements.rs
@@ -682,6 +682,7 @@ mod tests {
     use crate::elements::SegmentElement;
     use nom::*;
     use std::iter::repeat;
+    use log::trace;
 
     fn test_seek_head_serializer(seeks: Vec<(u64, Vec<u8>)>) -> bool {
         trace!("testing for {:?}", seeks);

--- a/tools/src/matroska_info.rs
+++ b/tools/src/matroska_info.rs
@@ -110,10 +110,10 @@ fn run(filename: &str) -> std::io::Result<()> {
                 SegmentElement::SeekHead(s) => {
                     println!("|+ Seek head at {:#0x} size {}", 0x0, b.data().offset(i));
                     for seek in s.positions.iter() {
-                        let id: u64 = ((seek.id[0] as u64) << 24) |
-                            ((seek.id[1] as u64) << 16) |
-                            ((seek.id[2] as u64) << 8) |
-                            seek.id[3] as u64;
+                        let id: u64 = ((seek.id[0] as u64) << 24)
+                            | ((seek.id[1] as u64) << 16)
+                            | ((seek.id[2] as u64) << 8)
+                            | seek.id[3] as u64;
 
                         let element_size = seek.size(0x4DBB);
                         let id_size = seek.id.size(0x53AB);
@@ -137,7 +137,10 @@ fn run(filename: &str) -> std::io::Result<()> {
                         };
 
                         println!("{} at {:#0x} size {}", name, 0x0, id_size);
-                        println!("|  + Seek position: {} size {}", seek.position, position_size);
+                        println!(
+                            "|  + Seek position: {} size {}",
+                            seek.position, position_size
+                        );
                     }
 
                     if seek_head.is_some() {


### PR DESCRIPTION
This PR contains fixes and stylistic changes related to Rust 2018, with a focus on making compilation possible on recent nightly releases (without warnings or errors) before tackling style-related updates.

**Todo:**

- [x] Update imports according to path clarity standard to enable minimal compile
- [x] Set `edition = "2018"` and run fix command
- [x] Combine blocks of like imports to reduce repetition (all local `use crate::*` imports grouped together, etc)
- [ ] Eliminate `#[macro_use]` and `extern crate ...`
