### PR TITLE
Simplify CI triggers

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,12 +1,6 @@
 name: Rust
 
-on:
-  pull_request:
-    branches:
-      - master
-  push:
-    branches:
-      - master
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
It seems to work. In this way, CI is triggered even for branches.