### PR TITLE
replace panics in matroska_info with errors

### DIFF
--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -17,3 +17,4 @@ matroska = { path=".." }
 nom = "5.0"
 pretty_env_logger = "0.3"
 better-panic = "0.2"
+err-derive = "^0.1"


### PR DESCRIPTION
Fixes #44.

`UnexpectedElement` and `Parse` unfortunately have to be strings due to the lifetimes associated with their sources.