### PR TITLE
Update quickcheck to 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ circular = "0.3"
 log = "0.4"
 
 [dev-dependencies]
-quickcheck = "0.9"
+quickcheck = "1"
 pretty_env_logger = "0.4"
 clap = { version = "3.0", features = ["derive"] }
 

--- a/src/serializer/ebml.rs
+++ b/src/serializer/ebml.rs
@@ -34,8 +34,6 @@ pub(crate) fn gen_vint(
     move |mut input| {
         let needed_bytes = vint_size(num);
 
-        assert!(num < (1u64 << 56) - 1);
-
         let num = num | 1u64 << (needed_bytes * 7);
 
         let mut i = needed_bytes - 1;
@@ -373,11 +371,13 @@ mod tests {
     use cookie_factory::gen::set_be_u64;
     use log::info;
     use nom::{HexDisplay, IResult};
-    use quickcheck::quickcheck;
+    use quickcheck::{quickcheck, TestResult};
 
     use crate::ebml::Error;
 
     use super::*;
+
+    const ALLOWED_ID_VALUES: u64 = (1u64 << 56) - 1;
 
     fn gen_u64(
         id: u64,
@@ -415,8 +415,11 @@ mod tests {
     }
 
     quickcheck! {
-      fn test_vint(i: u64) -> bool {
-        test_vint_serializer(i)
+      fn test_vint(i: u64) -> TestResult {
+        if i < ALLOWED_ID_VALUES  {
+          return TestResult::from_bool(test_vint_serializer(i));
+        }
+        TestResult::discard()
       }
     }
 

--- a/src/serializer/elements.rs
+++ b/src/serializer/elements.rs
@@ -563,11 +563,13 @@ mod tests {
 
     use super::*;
 
+    const ALLOWED_SEEK_POSITIONS: u64 = (1u64 << 56) - 1;
+
     impl Arbitrary for Seek {
-        fn arbitrary<G: Gen>(g: &mut G) -> Seek {
+        fn arbitrary(g: &mut Gen) -> Seek {
             Seek {
                 id: Vec::<u8>::arbitrary(g),
-                position: u64::arbitrary(g),
+                position: u64::arbitrary(g).min(ALLOWED_SEEK_POSITIONS - 1),
             }
         }
     }


### PR DESCRIPTION
- Update `quickcheck` to 1.0
- Fix tests using only an admissible input subset for `test_seek_head` and `test_vint`

This PR closes #80 