### PR TITLE
Fix demuxer test

### DIFF
--- a/src/demuxer.rs
+++ b/src/demuxer.rs
@@ -99,21 +99,23 @@ impl MkvDemuxer {
                 SegmentElement::Tracks(t) => {
                     trace!("got tracks: {:#?}", t);
                     self.tracks = if self.tracks.is_none() {
+                        let mut t = t;
+
                         // Only keep tracks we're interested in
-                        self.params.as_ref().and_then(|params| {
-                            params.track_numbers.as_ref().map(|track_numbers| {
-                                let mut t = t;
+                        if let Some(params) = &self.params {
+                            if let Some(track_numbers) = &params.track_numbers {
                                 t.tracks = t
                                     .tracks
                                     .into_iter()
                                     .filter(|tr| track_numbers.contains(&tr.track_number))
                                     .collect();
-                                t
-                            })
-                        })
+                            }
+                        };
+
+                        Some(t)
                     } else {
                         return Err(Err::Error(custom_error(input, 1)));
-                    };
+                    }
                 }
                 el => {
                     debug!("got element: {:#?}", el);

--- a/src/demuxer.rs
+++ b/src/demuxer.rs
@@ -379,15 +379,14 @@ mod tests {
             Box::new(MkvDemuxer::new()),
             Box::new(AccReader::new(Cursor::new(webm))),
         );
-        info!("read headers: {:?}", context.read_headers().unwrap());
-        info!("streams: {:?}", context.info.streams);
-        info!("event: {:?}", context.read_event().unwrap());
-        info!("event: {:?}", context.read_event().unwrap());
-        info!("event: {:?}", context.read_event().unwrap());
-        info!("event: {:?}", context.read_event().unwrap());
-        info!("event: {:?}", context.read_event().unwrap());
-        info!("event: {:?}", context.read_event().unwrap());
-        info!("event: {:?}", context.read_event().unwrap());
-        info!("event: {:?}", context.read_event().unwrap());
+        context.read_headers().unwrap();
+        context.read_event().unwrap();
+        context.read_event().unwrap();
+        context.read_event().unwrap();
+        context.read_event().unwrap();
+        context.read_event().unwrap();
+        context.read_event().unwrap();
+        context.read_event().unwrap();
+        context.read_event().unwrap();
     }
 }

--- a/src/demuxer.rs
+++ b/src/demuxer.rs
@@ -379,14 +379,14 @@ mod tests {
             Box::new(MkvDemuxer::new()),
             Box::new(AccReader::new(Cursor::new(webm))),
         );
-        context.read_headers().unwrap();
-        context.read_event().unwrap();
-        context.read_event().unwrap();
-        context.read_event().unwrap();
-        context.read_event().unwrap();
-        context.read_event().unwrap();
-        context.read_event().unwrap();
-        context.read_event().unwrap();
-        context.read_event().unwrap();
+
+        println!("{:?}", context.read_headers().unwrap());
+
+        while let Ok(event) = context.read_event() {
+            println!("event: {:?}", event);
+            if let Event::Eof = event {
+                break;
+            }
+        }
     }
 }

--- a/src/ebml.rs
+++ b/src/ebml.rs
@@ -166,6 +166,10 @@ pub fn parse_binary_data(size: u64) -> impl Fn(&[u8]) -> IResult<&[u8], Vec<u8>,
     }
 }
 
+pub fn parse_binary_data_ref(size: u64) -> impl Fn(&[u8]) -> IResult<&[u8], &[u8], Error> {
+    move |input| map(take(usize_error(input, size)?), |data| data)(input)
+}
+
 //FIXME: handle default values
 //FIXME: is that really following IEEE_754-1985 ?
 pub fn parse_float_data(size: u64) -> impl Fn(&[u8]) -> IResult<&[u8], f64, Error> {
@@ -217,11 +221,8 @@ pub fn ebml_binary<'a>(id: u64) -> impl Fn(&'a [u8]) -> IResult<&'a [u8], Vec<u8
     compute_ebml_type(id, parse_binary_data)
 }
 
-pub fn ebml_binary_ref(id: u64) -> impl Fn(&[u8]) -> IResult<&[u8], &[u8], Error> {
-    move |i| {
-        pair(verify(vid, |val| *val == id), vint)(i)
-            .and_then(|(i, (_, size))| take(usize_error(i, size)?)(i))
-    }
+pub fn ebml_binary_ref<'a>(id: u64) -> impl Fn(&'a [u8]) -> IResult<&'a [u8], &'a [u8], Error> {
+    compute_ebml_type(id, parse_binary_data_ref)
 }
 
 pub fn ebml_master<'a, G, O1>(

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -40,7 +40,7 @@ where
     move |input| {
         pair(vint, opt(ebml_binary(0xBF)))(input).and_then(|(i, (size, crc))| {
             take(usize_error(i, size - if crc.is_some() { 6 } else { 0 })?)(i)
-                .and_then(|(_, data)| second(data))
+                .and_then(|(i, data)| second(data).map(|(_, val)| (i, val)))
         })
     }
 }


### PR DESCRIPTION
This PR fixes a demuxer test applying some of the following changes:
- Fix sub elements parsing
- Introduce a new matroska permutation parser that skips void elements
- Fix wrong tracks handling in demuxer code