### PR TITLE
BlockGroup silently ignored

### DIFF
--- a/src/elements.rs
+++ b/src/elements.rs
@@ -238,7 +238,7 @@ pub struct BlockGroup<'a> {
 
 //https://datatracker.ietf.org/doc/html/draft-lhomme-cellar-matroska-03#section-7.3.16
 pub fn block_group(input: &[u8]) -> IResult<&[u8], BlockGroup, Error> {
-    ebml_master(0x5854, |inp| {
+    ebml_master(0xA0, |inp| {
         matroska_permutation((
             complete(ebml_binary_ref(0xA1)),
             complete(ebml_binary(0xA2)),

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -260,7 +260,7 @@ pub fn block_group(input: &[u8]) -> IResult<&[u8], BlockGroup, Error> {
                     block_virtual: t.1,
                     block_additions: t.2,
                     block_duration: t.3,
-                    reference_priority: value_error(inp, t.4)?,
+                    reference_priority: value_error(inp, t.4).unwrap_or(0),
                     reference_block: t.5,
                     reference_virtual: t.6,
                     codec_state: t.7,


### PR DESCRIPTION
ID is wrong and groups without reference_priority are skipped.

The wider issue though is that `matroska_permutation` ignores all errors.