### PR TITLE
Parses simple blocks after a block group are silently ignored.

### DIFF
--- a/src/demuxer.rs
+++ b/src/demuxer.rs
@@ -269,8 +269,8 @@ impl<'a> Cluster<'a> {
     pub fn generate_packets(&self, tracks: &Tracks) -> Vec<Event> {
         let mut v = Vec::new();
 
-        for block_data in self.simple_block.iter() {
-            if let Ok((i, block)) = simple_block(block_data) {
+        for block_data in self.block.iter() {
+            if let Ok((i, block)) = simple_block(block_data.block) {
                 debug!("parsing simple block: {:?}", block);
                 if let Some(index) = tracks.lookup(block.track_number) {
                     let packet = Packet {

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -238,7 +238,7 @@ pub struct BlockGroup<'a> {
 
 //https://datatracker.ietf.org/doc/html/draft-lhomme-cellar-matroska-03#section-7.3.16
 pub fn block_group(input: &[u8]) -> IResult<&[u8], BlockGroup, Error> {
-    ebml_master(0x5854, |inp| {
+    ebml_master(0xA0, |inp| {
         matroska_permutation((
             complete(ebml_binary_ref(0xA1)),
             complete(ebml_binary(0xA2)),

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -260,7 +260,7 @@ pub fn block_group(input: &[u8]) -> IResult<&[u8], BlockGroup, Error> {
                     block_virtual: t.1,
                     block_additions: t.2,
                     block_duration: t.3,
-                    reference_priority: value_error(inp, t.4)?,
+                    reference_priority: value_error(inp, t.4).unwrap_or(0),
                     reference_block: t.5,
                     reference_virtual: t.6,
                     codec_state: t.7,

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -4,6 +4,7 @@ use nom::{
     multi::{many0, many1},
     number::streaming::{be_i16, be_u8},
     sequence::{pair, tuple},
+    branch::alt,
     IResult,
 };
 
@@ -178,8 +179,7 @@ pub struct Cluster<'a> {
     pub silent_tracks: Option<SilentTracks>,
     pub position: Option<u64>,
     pub prev_size: Option<u64>,
-    pub simple_block: Vec<&'a [u8]>,
-    pub block_group: Vec<BlockGroup<'a>>,
+    pub block: Vec<BlockGroup<'a>>,
     pub encrypted_block: Option<&'a [u8]>,
 }
 
@@ -189,7 +189,6 @@ pub fn cluster(input: &[u8]) -> IResult<&[u8], SegmentElement, Error> {
         complete(silent_tracks),
         complete(ebml_uint(0xA7)),
         complete(ebml_uint(0xAB)),
-        many0(complete(ebml_binary_ref(0xA3))),
         many0(complete(block_group)),
         complete(ebml_binary_ref(0xAF)),
     ))(input)
@@ -201,9 +200,8 @@ pub fn cluster(input: &[u8]) -> IResult<&[u8], SegmentElement, Error> {
                 silent_tracks: t.1,
                 position: t.2,
                 prev_size: t.3,
-                simple_block: value_error(input, t.4)?,
-                block_group: value_error(input, t.5)?,
-                encrypted_block: t.6,
+                block: value_error(input, t.4)?,
+                encrypted_block: t.5,
             }),
         ))
     })
@@ -238,6 +236,19 @@ pub struct BlockGroup<'a> {
 
 //https://datatracker.ietf.org/doc/html/draft-lhomme-cellar-matroska-03#section-7.3.16
 pub fn block_group(input: &[u8]) -> IResult<&[u8], BlockGroup, Error> {
+    alt((map(complete(ebml_binary_ref(0xA3)), |block| BlockGroup{
+        block,
+        block_virtual: None,
+        block_additions: None,
+        block_duration: None,
+        reference_priority: 0,
+        reference_block: None,
+        reference_virtual: None,
+        codec_state: None,
+        discard_padding: None,
+        slices: None,
+        reference_frame: None
+    }),
     ebml_master(0xA0, |inp| {
         matroska_permutation((
             complete(ebml_binary_ref(0xA1)),
@@ -270,7 +281,7 @@ pub fn block_group(input: &[u8]) -> IResult<&[u8], BlockGroup, Error> {
                 },
             ))
         })
-    })(input)
+    })))(input)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/muxer.rs
+++ b/src/muxer.rs
@@ -10,7 +10,7 @@ use av_format::{common::GlobalInfo, error::*, muxer::*, stream::Stream};
 use crate::{
     ebml::EBMLHeader,
     elements::{
-        Audio, Cluster, Colour, Info, Lacing, Seek, SeekHead, SimpleBlock, TrackEntry, TrackType,
+        Audio, Cluster, BlockGroup, Colour, Info, Lacing, Seek, SeekHead, SimpleBlock, TrackEntry, TrackType,
         Tracks, Video,
     },
     serializer::{
@@ -349,8 +349,19 @@ impl Muxer for MkvMuxer {
                     silent_tracks: None,
                     position: None,
                     prev_size: None,
-                    simple_block: simple_blocks,
-                    block_group: Vec::new(),
+                    block: simple_blocks.iter().map(|block| BlockGroup{
+                        block,
+                        block_virtual: None,
+                        block_additions: None,
+                        block_duration: None,
+                        reference_priority: 0,
+                        reference_block: None,
+                        reference_virtual: None,
+                        codec_state: None,
+                        discard_padding: None,
+                        slices: None,
+                        reference_frame: None
+                    }).collect(),
                     encrypted_block: None,
                 };
 
@@ -401,8 +412,19 @@ impl Muxer for MkvMuxer {
                 silent_tracks: None,
                 position: None,
                 prev_size: None,
-                simple_block: simple_blocks,
-                block_group: Vec::new(),
+                block: simple_blocks.iter().map(|block| BlockGroup{
+                    block,
+                    block_virtual: None,
+                    block_additions: None,
+                    block_duration: None,
+                    reference_priority: 0,
+                    reference_block: None,
+                    reference_virtual: None,
+                    codec_state: None,
+                    discard_padding: None,
+                    slices: None,
+                    reference_frame: None
+                }).collect(),
                 encrypted_block: None,
             };
 

--- a/src/serializer/elements.rs
+++ b/src/serializer/elements.rs
@@ -430,11 +430,9 @@ fn gen_track_entry_video_projection<'a, 'b>(
 
 impl<'a> EbmlSize for Cluster<'a> {
     fn capacity(&self) -> usize {
-        self.timecode.size(0xE7) + self.silent_tracks.size(0x5854) + self.position.size(0xA7) +
-      self.prev_size.size(0xAB) + self.simple_block.size(0xA3) +
-      // TODO: implement for BlockGroup
-      // self.block_group.size(0xA0) +
-      self.encrypted_block.size(0xAF)
+        /*self.timecode.size(0xE7) + self.silent_tracks.size(0x5854) + self.position.size(0xA7) +
+      self.prev_size.size(0xAB) + self.block.size(0xA0) +
+      self.encrypted_block.size(0xAF)*/unimplemented!()
     }
 }
 
@@ -443,7 +441,7 @@ pub(crate) fn gen_cluster<'a, 'b>(
 ) -> impl Fn((&'b mut [u8], usize)) -> Result<(&'b mut [u8], usize), GenError> + 'a {
     move |input| {
         let byte_capacity = vint_size(c.capacity() as u64)?;
-        gen_ebml_master(
+        /*gen_ebml_master(
             0x1F43B675,
             byte_capacity,
             tuple((
@@ -451,12 +449,10 @@ pub(crate) fn gen_cluster<'a, 'b>(
                 gen_opt(c.silent_tracks.as_ref(), gen_silent_tracks),
                 gen_opt_copy(c.position, |v| gen_ebml_uint(0xA7, v)),
                 gen_opt_copy(c.prev_size, |v| gen_ebml_uint(0xAB, v)),
-                gen_many(&c.simple_block, |v| gen_ebml_binary(0xA3, v)),
-                // TODO: implement for BlockGroup
-                // gen_many(&c.block_group, gen_block_group)
+                gen_many(&c.block, |v| gen_block_group),
                 gen_opt(c.encrypted_block.as_ref(), |v| gen_ebml_binary(0xAF, v)),
             )),
-        )(input)
+        )(input)*/unimplemented!()
     }
 }
 


### PR DESCRIPTION
Simple blocks after a block group are silently ignored.
Parsing into the existing simple_block would reorder.
This parses all simple blocks into struct BlockGroup to allow any interleaving of simple blocks or block groups inside a cluster while preserving the order.
If that's an acceptable solution, the serialization needs to be updated.
