### PR TITLE
Fix new clippy warnings

### DIFF
--- a/src/elements.rs
+++ b/src/elements.rs
@@ -1073,7 +1073,7 @@ mod tests {
                         }
                     };
 
-                    index = new_index as usize;
+                    index = new_index;
                 }
                 e => {
                     let max_index = min(mkv.len(), index + 200);
@@ -1123,7 +1123,7 @@ mod tests {
                         }
                     };
 
-                    index = new_index as usize;
+                    index = new_index;
                 }
                 e => {
                     let max_index = min(webm.len(), index + 200);

--- a/src/muxer.rs
+++ b/src/muxer.rs
@@ -454,7 +454,7 @@ impl Muxer for MkvMuxer {
         Ok(())
     }
 
-    fn set_option<'a>(&mut self, _key: &str, _val: Value<'a>) -> Result<()> {
+    fn set_option(&mut self, _key: &str, _val: Value<'_>) -> Result<()> {
         Ok(())
     }
 }

--- a/src/serializer/ebml.rs
+++ b/src/serializer/ebml.rs
@@ -301,7 +301,7 @@ pub trait EbmlSize {
         let self_size = self.capacity();
         let size_tag_size = vint_size(self_size as u64).unwrap_or(0);
 
-        id_size as usize + size_tag_size as usize + self_size as usize
+        id_size as usize + size_tag_size as usize + self_size
     }
 }
 
@@ -339,7 +339,7 @@ impl<T: EbmlSize> EbmlSize for Option<T> {
                 let self_size = self.capacity();
                 let size_tag_size = vint_size(self_size as u64).unwrap_or(0);
 
-                id_size as usize + size_tag_size as usize + self_size as usize
+                id_size as usize + size_tag_size as usize + self_size
             }
             None => 0,
         }


### PR DESCRIPTION
Some [new clippy warnings](https://github.com/rust-av/matroska/actions/runs/4544731886/jobs/8011595533?pr=98) have come up since the last commit to master. This PR just fixes those few small things.