### PR TITLE
Replace EBML parsing error code (u8) with error enum

### DIFF
--- a/src/demuxer.rs
+++ b/src/demuxer.rs
@@ -15,7 +15,7 @@ use av_format::{
 };
 
 use crate::{
-    ebml::{self, custom_error, ebml_header, EBMLHeader},
+    ebml::{self, custom_error, ebml_header, EBMLHeader, EbmlError},
     elements::{
         segment, segment_element, simple_block, Audio, Cluster, Info, SeekHead, SegmentElement,
         TrackEntry, TrackType, Tracks, Video,
@@ -85,7 +85,7 @@ impl MkvDemuxer {
                     self.seek_head = if self.seek_head.is_none() {
                         Some(s)
                     } else {
-                        return Err(Err::Error(custom_error(input, 1)));
+                        return Err(custom_error(input, EbmlError::DuplicateSegment));
                     };
                 }
                 SegmentElement::Info(i) => {
@@ -93,7 +93,7 @@ impl MkvDemuxer {
                     self.info = if self.info.is_none() {
                         Some(i)
                     } else {
-                        return Err(Err::Error(custom_error(input, 1)));
+                        return Err(custom_error(input, EbmlError::DuplicateSegment));
                     };
                 }
                 SegmentElement::Tracks(t) => {
@@ -111,7 +111,7 @@ impl MkvDemuxer {
 
                         Some(t)
                     } else {
-                        return Err(Err::Error(custom_error(input, 1)));
+                        return Err(custom_error(input, EbmlError::DuplicateSegment));
                     }
                 }
                 el => {


### PR DESCRIPTION
This is a suggestion to make the EBML errors better. Feel free to change things or just let me know what you think.

Changes:
1. Introduce `ebml::EbmlError` enum to represent errors instead of u8 error codes.
2. Change some of the error code values (the values 1 and 104 were used ambiguously)
3. Make the helper function `custom_error` return a `nom:Err` (specifically, the recoverable `Error` variant) wrapped around the `ebml::Error` instead of just the `ebml::Error`. This simplifies the function calls.

I thought about `#[repr(u8)]` for the new enum, but realistically the enclosing `ebml::Error` struct will be padded anyways, so it probably doesn't matter if the enum is represented as a u16 or even larger in the future.

I'm not sure about the actual error codes. If the numerical values are supposed to be expressive, it would make sense to think of some kind of numbering scheme for the error codes before merging. Otherwise, the numerical values can (IMO) just be removed.