### PR TITLE
Change the EBML error type (again)

### DIFF
--- a/src/demuxer.rs
+++ b/src/demuxer.rs
@@ -61,7 +61,7 @@ impl MkvDemuxer {
     pub fn parse_until_tracks<'a>(
         &mut self,
         original_input: &'a [u8],
-    ) -> IResult<&'a [u8], (), ebml::Error<'a>> {
+    ) -> IResult<&'a [u8], (), ebml::Error> {
         let (i1, header) = ebml_header(original_input)?;
 
         self.header = Some(header);
@@ -85,7 +85,7 @@ impl MkvDemuxer {
                     self.seek_head = if self.seek_head.is_none() {
                         Some(s)
                     } else {
-                        return Err(custom_error(input, EbmlError::DuplicateSegment));
+                        return Err(custom_error(EbmlError::DuplicateSegment(0x114D9B74)));
                     };
                 }
                 SegmentElement::Info(i) => {
@@ -93,7 +93,7 @@ impl MkvDemuxer {
                     self.info = if self.info.is_none() {
                         Some(i)
                     } else {
-                        return Err(custom_error(input, EbmlError::DuplicateSegment));
+                        return Err(custom_error(EbmlError::DuplicateSegment(0x1549A966)));
                     };
                 }
                 SegmentElement::Tracks(t) => {
@@ -111,7 +111,7 @@ impl MkvDemuxer {
 
                         Some(t)
                     } else {
-                        return Err(custom_error(input, EbmlError::DuplicateSegment));
+                        return Err(custom_error(EbmlError::DuplicateSegment(0x1654AE6B)));
                     }
                 }
                 el => {

--- a/src/ebml.rs
+++ b/src/ebml.rs
@@ -12,56 +12,64 @@ use nom::{
 use crate::permutation::matroska_permutation;
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct Error<'a> {
-    input: &'a [u8],
-    kind: ErrorKind,
-}
-
-#[derive(Debug, PartialEq, Eq)]
-pub enum ErrorKind {
+pub enum Error {
+    /// nom returned an error.
     Nom(nom::error::ErrorKind),
+
+    /// nom did not return an error, but the EBML is incorrect.
     Custom(EbmlError),
 }
 
+// TODO: Add Element IDs (u64) to more of these variants
+
+/// The `u64` contained in some of these error variants represents the
+/// EBML or Matroska Element ID of the element where the error occurred.
+///
+/// For an overview of all Element IDs, see:
+///
+/// https://www.rfc-editor.org/rfc/rfc8794.html#name-ebml-element-ids-registry
+///
+/// https://www.ietf.org/archive/id/draft-ietf-cellar-matroska-15.html#section-27.1-11
 #[derive(Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum EbmlError {
     /// The value of an unsigned integer does not fit into the platform's
     /// native uint type. This can not happen on 64-bit platforms.
-    UintTooLarge = 0,
+    UintTooLarge(u64),
 
     /// A required value was not found by the parser.
-    MissingRequiredValue = 1,
+    MissingRequiredValue(u64),
 
     /// One of the segment element types was discovered more than once in the input.
-    DuplicateSegment = 2,
+    DuplicateSegment(u64),
 
     /// The VINT_WIDTH is 8 or more, which means that the resulting variable-size
     /// integer is more than 8 octets wide. This is currently not supported.
-    VintTooWide = 100,
+    VintTooWide,
+
+    /// The VINT_WIDTH of this Element ID is 5 or more, which is not allowed as
+    /// per the Matroska specification (Element IDs can be 1 to 5 octets long).
+    IDTooWide,
 
     /// A signed integer element has declared a length of more than 8 octets,
     /// which is not allowed.
-    IntTooWide = 101,
+    IntTooWide(u64),
 
     /// An unsigned integer element has declared a length of more than 8 octets,
     /// which is not allowed.
-    UintTooWide = 102,
+    UintTooWide(u64),
 
     /// A float element has declared a length that is not 0, 4 or 8 octets,
     /// which is not allowed.
-    FloatWidthIncorrect = 103,
+    FloatWidthIncorrect(u64),
 
     /// A string element contains non-UTF-8 data, which is not allowed.
-    StringNotUtf8 = 104,
+    StringNotUtf8(u64),
 }
 
-impl<'a> nom::error::ParseError<&'a [u8]> for Error<'a> {
-    fn from_error_kind(input: &'a [u8], kind: nom::error::ErrorKind) -> Self {
-        Error {
-            input,
-            kind: ErrorKind::Nom(kind),
-        }
+impl<'a> nom::error::ParseError<&'a [u8]> for Error {
+    fn from_error_kind(_input: &'a [u8], kind: nom::error::ErrorKind) -> Self {
+        Error::Nom(kind)
     }
 
     fn append(_input: &'a [u8], _kind: nom::error::ErrorKind, other: Self) -> Self {
@@ -69,24 +77,21 @@ impl<'a> nom::error::ParseError<&'a [u8]> for Error<'a> {
     }
 }
 
-pub fn custom_error(input: &[u8], code: EbmlError) -> nom::Err<Error> {
-    nom::Err::Error(Error {
-        input,
-        kind: ErrorKind::Custom(code),
-    })
+pub fn custom_error(err: EbmlError) -> nom::Err<Error> {
+    nom::Err::Error(Error::Custom(err))
 }
 
-pub(crate) fn usize_error(input: &[u8], size: u64) -> Result<usize, nom::Err<Error>> {
+pub(crate) fn usize_error(id: u64, size: u64) -> Result<usize, nom::Err<Error>> {
     usize::try_from(size).map_err(|_| {
         log::error!("Not possible to convert size into usize");
-        custom_error(input, EbmlError::UintTooLarge)
+        custom_error(EbmlError::UintTooLarge(id))
     })
 }
 
-pub(crate) fn value_error<T>(input: &[u8], value: Option<T>) -> Result<T, nom::Err<Error>> {
+pub(crate) fn value_error<T>(id: u64, value: Option<T>) -> Result<T, nom::Err<Error>> {
     value.ok_or_else(|| {
         log::error!("Not possible to get the requested value");
-        custom_error(input, EbmlError::MissingRequiredValue)
+        custom_error(EbmlError::MissingRequiredValue(id))
     })
 }
 
@@ -99,7 +104,7 @@ pub fn vint(input: &[u8]) -> IResult<&[u8], u64, Error> {
     let len = v.leading_zeros();
 
     if len == 8 {
-        return Err(custom_error(input, EbmlError::VintTooWide));
+        return Err(custom_error(EbmlError::VintTooWide));
     }
 
     if input.len() <= len as usize {
@@ -136,7 +141,7 @@ pub fn vid(input: &[u8]) -> IResult<&[u8], u64, Error> {
     let len = v.leading_zeros();
 
     if len == 8 {
-        return Err(custom_error(input, EbmlError::VintTooWide));
+        return Err(custom_error(EbmlError::IDTooWide));
     }
 
     if input.len() <= len as usize {
@@ -156,12 +161,12 @@ pub fn vid(input: &[u8]) -> IResult<&[u8], u64, Error> {
     Ok((&input[len as usize + 1..], val))
 }
 
-pub fn parse_uint_data(size: u64) -> impl Fn(&[u8]) -> IResult<&[u8], u64, Error> {
+pub fn parse_uint_data(id: u64, size: u64) -> impl Fn(&[u8]) -> IResult<&[u8], u64, Error> {
     move |input| {
         let mut val = 0;
 
         if size > 8 {
-            return Err(custom_error(input, EbmlError::UintTooWide));
+            return Err(custom_error(EbmlError::UintTooWide(id)));
         }
 
         for i in input.iter().take(size as usize) {
@@ -172,12 +177,12 @@ pub fn parse_uint_data(size: u64) -> impl Fn(&[u8]) -> IResult<&[u8], u64, Error
     }
 }
 
-pub fn parse_int_data(size: u64) -> impl Fn(&[u8]) -> IResult<&[u8], i64, Error> {
+pub fn parse_int_data(id: u64, size: u64) -> impl Fn(&[u8]) -> IResult<&[u8], i64, Error> {
     move |input| {
         let mut val = 0;
 
         if size > 8 {
-            return Err(custom_error(input, EbmlError::IntTooWide));
+            return Err(custom_error(EbmlError::IntTooWide(id)));
         }
 
         for i in input.iter().take(size as usize) {
@@ -188,32 +193,28 @@ pub fn parse_int_data(size: u64) -> impl Fn(&[u8]) -> IResult<&[u8], i64, Error>
     }
 }
 
-pub fn parse_str_data(size: u64) -> impl Fn(&[u8]) -> IResult<&[u8], String, Error> {
+pub fn parse_str_data(id: u64, size: u64) -> impl Fn(&[u8]) -> IResult<&[u8], String, Error> {
     move |input| {
-        take(usize_error(input, size)?)(input).and_then(|(i, data)| {
+        take(usize_error(id, size)?)(input).and_then(|(i, data)| {
             match String::from_utf8(data.to_owned()) {
                 Ok(s) => Ok((i, s)),
-                Err(_) => return Err(custom_error(i, EbmlError::StringNotUtf8)),
+                Err(_) => Err(custom_error(EbmlError::StringNotUtf8(id))),
             }
         })
     }
 }
 
-pub fn parse_binary_data(size: u64) -> impl Fn(&[u8]) -> IResult<&[u8], Vec<u8>, Error> {
-    move |input| {
-        map(take(usize_error(input, size)?), |data: &[u8]| {
-            data.to_owned()
-        })(input)
-    }
+pub fn parse_binary_data(id: u64, size: u64) -> impl Fn(&[u8]) -> IResult<&[u8], Vec<u8>, Error> {
+    move |input| map(take(usize_error(id, size)?), |data: &[u8]| data.to_owned())(input)
 }
 
-pub fn parse_binary_data_ref(size: u64) -> impl Fn(&[u8]) -> IResult<&[u8], &[u8], Error> {
-    move |input| map(take(usize_error(input, size)?), |data| data)(input)
+pub fn parse_binary_data_ref(id: u64, size: u64) -> impl Fn(&[u8]) -> IResult<&[u8], &[u8], Error> {
+    move |input| map(take(usize_error(id, size)?), |data| data)(input)
 }
 
 //FIXME: handle default values
 //FIXME: is that really following IEEE_754-1985 ?
-pub fn parse_float_data(size: u64) -> impl Fn(&[u8]) -> IResult<&[u8], f64, Error> {
+pub fn parse_float_data(id: u64, size: u64) -> impl Fn(&[u8]) -> IResult<&[u8], f64, Error> {
     move |input| {
         if size == 0 {
             Ok((input, 0f64))
@@ -222,7 +223,7 @@ pub fn parse_float_data(size: u64) -> impl Fn(&[u8]) -> IResult<&[u8], f64, Erro
         } else if size == 8 {
             map_parser(take(8usize), be_f64)(input)
         } else {
-            Err(custom_error(input, EbmlError::FloatWidthIncorrect))
+            Err(custom_error(EbmlError::FloatWidthIncorrect(id)))
         }
     }
 }
@@ -232,12 +233,12 @@ fn compute_ebml_type<'a, G, H, O1>(
     second: G,
 ) -> impl Fn(&'a [u8]) -> IResult<&'a [u8], O1, Error>
 where
-    G: Fn(u64) -> H,
-    H: Parser<&'a [u8], O1, Error<'a>>,
+    G: Fn(u64, u64) -> H,
+    H: Parser<&'a [u8], O1, Error>,
 {
     move |i| {
-        flat_map(pair(verify(vid, |val| *val == id), vint), |(_, size)| {
-            second(size)
+        flat_map(pair(verify(vid, |val| *val == id), vint), |(id, size)| {
+            second(id, size)
         })(i)
     }
 }
@@ -275,20 +276,20 @@ where
 {
     move |i| {
         pair(verify(vid, |val| *val == id), vint)(i)
-            .and_then(|(i, (_, size))| map_parser(take(usize_error(i, size)?), second)(i))
+            .and_then(|(i, (_, size))| map_parser(take(usize_error(0, size)?), second)(i))
     }
 }
 
-pub fn eat_void<'a, G, O1>(second: G) -> impl Fn(&'a [u8]) -> IResult<&'a [u8], O1, Error<'a>>
+pub fn eat_void<'a, G, O1>(second: G) -> impl Fn(&'a [u8]) -> IResult<&'a [u8], O1, Error>
 where
-    G: Parser<&'a [u8], O1, Error<'a>> + Copy,
+    G: Parser<&'a [u8], O1, Error> + Copy,
 {
     move |i| preceded(opt(skip_void), second)(i)
 }
 
 pub fn skip_void(input: &[u8]) -> IResult<&[u8], &[u8], Error> {
     pair(verify(vid, |val| *val == 0xEC), vint)(input)
-        .and_then(|(i, (_, size))| take(usize_error(input, size)?)(i))
+        .and_then(|(i, (_, size))| take(usize_error(0, size)?)(i))
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -321,7 +322,7 @@ pub fn ebml_header(input: &[u8]) -> IResult<&[u8], EBMLHeader, Error> {
                     read_version: t.1.unwrap_or(1),
                     max_id_length: t.2.unwrap_or(4),
                     max_size_length: t.3.unwrap_or(8),
-                    doc_type: value_error(input, t.4)?,
+                    doc_type: value_error(0x4282, t.4)?,
                     doc_type_version: t.5.unwrap_or(1),
                     doc_type_read_version: t.6.unwrap_or(1),
                 },


### PR DESCRIPTION
After #101, I decided to try and improve the errors more.

The ebml error type now looks like this:

```rust
#[derive(Debug, PartialEq, Eq)]
pub enum Error {
    /// nom returned an error.
    Nom(nom::error::ErrorKind),

    /// nom did not return an error, but the EBML is incorrect.
    Custom(EbmlError),
}
```

It's fairly self-explanatory, but something to note is that I removed the `input: &'a [u8]` field from the error. The reason for this is that I don't see a big advantage in keeping it. It was actually kind of annoying to get the entire (sometimes >10MiB) input dumped to the terminal.

The `EbmlError` enum now also includes an EBML/Matroska element ID in a lot of cases. This required changing some functions to "pass through" the ID. I hope this isn't a big performance hit, but can always be removed later if necessary.

The good thing about this is that we now get a way better error. For example:
> thread 'ebml::tests::read_header' panicked at 'called `Result::unwrap()` on an `Err` value: Error(Custom(MissingRequiredValue(17026)))', src/ebml.rs:362:49

17026 is 0x4282, which can easily be found in the specification as the `DocType` element.