### PR TITLE
Implement CRC-32 elements & verification

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ av-data = "0.4.1"
 av-format = "0.7"
 circular = "0.3"
 log = "0.4"
+crc = "3.0.1"
 
 [dev-dependencies]
 quickcheck = "1"

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -8,8 +8,8 @@ use nom::{
 };
 
 use crate::ebml::{
-    crc, eat_void, ebml_binary, ebml_binary_ref, ebml_float, ebml_int, ebml_master, ebml_str,
-    ebml_uint, usize_error, value_error, vid, vint, Error, checksum,
+    checksum, crc, eat_void, ebml_binary, ebml_binary_ref, ebml_float, ebml_int, ebml_master,
+    ebml_str, ebml_uint, usize_error, value_error, vid, vint, Error,
 };
 use crate::permutation::matroska_permutation;
 


### PR DESCRIPTION
I found what made the tests from #106 fail: CRC elements aren't handled in the EBML header.

Changes:
1. Add `parse_binary_exact` to get an exact amount of bytes in an array
2. Add combinator-style functions to get the checksum from the input (`fn crc`) and to verify the data with the checksum (`fn checksum`)
(2.5) Add the `crc` crate to calculate the checksum(s) as per the [specification](https://www.rfc-editor.org/rfc/rfc8794.html#section-11.3.1-1.16).
3. Use these functions in `ebml_header` and `sub_element`

The complete error handling for CRC-32 is a [bit more involved](https://www.rfc-editor.org/rfc/rfc8794.html#name-considerations-for-reading-) than just returning an error, but I'd say it's good enough for now.