### PR TITLE
Introduce `Uuid` type from `uuid` crate for UIDs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ av-format = "0.7"
 circular = "0.3"
 log = "0.4"
 crc = "3.0.1"
+uuid = "1.3.0"
 
 [dev-dependencies]
 quickcheck = "1"

--- a/src/serializer/ebml.rs
+++ b/src/serializer/ebml.rs
@@ -247,11 +247,15 @@ pub(crate) fn gen_ebml_str<'a, 'b>(
     }
 }
 
-pub(crate) fn gen_ebml_binary<'a, 'b>(
+pub(crate) fn gen_ebml_binary<'a, 'b, S>(
     id: u64,
-    s: &'a [u8],
-) -> impl Fn((&'b mut [u8], usize)) -> Result<(&'b mut [u8], usize), GenError> + 'a {
+    s: S,
+) -> impl Fn((&'b mut [u8], usize)) -> Result<(&'b mut [u8], usize), GenError> + 'a
+where
+    S: AsRef<[u8]> + 'a,
+{
     move |input| {
+        let s = s.as_ref();
         let v = vint_size(s.len() as u64)?;
 
         let (buf, ofs_len) = gen_vid(id)(input)?;
@@ -373,6 +377,12 @@ impl<'a> EbmlSize for Vec<&'a [u8]> {
 impl EbmlSize for Vec<u64> {
     fn capacity(&self) -> usize {
         self.len() * 8
+    }
+}
+
+impl EbmlSize for uuid::Uuid {
+    fn capacity(&self) -> usize {
+        16
     }
 }
 

--- a/tools/src/matroska_info.rs
+++ b/tools/src/matroska_info.rs
@@ -8,7 +8,7 @@ use err_derive::Error;
 use nom::{Err, Offset};
 
 use matroska::ebml::ebml_header;
-use matroska::elements::{segment, segment_element, SegmentElement};
+use matroska::elements::{segment, segment_element, SegmentElement, Uuid};
 use matroska::serializer::ebml::EbmlSize;
 
 #[derive(Debug, Error)]
@@ -175,7 +175,7 @@ fn run(filename: &str) -> Result<(), InfoError> {
                     println!("|+ Segment information");
                     println!(
                         "| + Segment UID: {}",
-                        format_uid(i.segment_uid.as_ref().unwrap_or(&Vec::new()))
+                        i.segment_uid.map(format_uid).unwrap_or(String::new())
                     );
                     println!("| + Timestamp scale: {}", i.timecode_scale);
                     if let Some(f) = i.duration {
@@ -336,8 +336,9 @@ fn run(filename: &str) -> Result<(), InfoError> {
     Ok(())
 }
 
-fn format_uid(uid: &[u8]) -> String {
-    uid.iter()
+fn format_uid(uid: Uuid) -> String {
+    uid.as_bytes()
+        .iter()
         .map(|b| format!("{b:#x}"))
         .collect::<Vec<_>>()
         .join(" ")


### PR DESCRIPTION
The [uuid docs](https://docs.rs/uuid/1.3.0/uuid/). The `Uuid` struct is basically a thin wrapper around `[u8; 16]` with some helper functions and ways to create different versions of UUIDs.

If creating UUIDs ever gets relevant, the only reference I can find is for the [SegmentUUID element](https://www.ietf.org/archive/id/draft-ietf-cellar-matroska-15.html#name-segmentuuid-element) which states that it is equivalent to a UUID v4.