### PR TITLE
Introduce helper method for Element Sizes

### DIFF
--- a/src/ebml.rs
+++ b/src/ebml.rs
@@ -215,11 +215,9 @@ pub fn parse_int_data(id: u64, size: usize) -> impl Fn(&[u8]) -> EbmlResult<i64>
 
 pub fn parse_str_data(id: u64, size: usize) -> impl Fn(&[u8]) -> EbmlResult<String> {
     move |input| {
-        take(size)(input).and_then(|(i, data)| {
-            match String::from_utf8(data.to_owned()) {
-                Ok(s) => Ok((i, s)),
-                Err(_) => ebml_err(ErrorKind::StringNotUtf8(id)),
-            }
+        take(size)(input).and_then(|(i, data)| match String::from_utf8(data.to_owned()) {
+            Ok(s) => Ok((i, s)),
+            Err(_) => ebml_err(ErrorKind::StringNotUtf8(id)),
         })
     }
 }
@@ -322,8 +320,7 @@ where
 }
 
 pub fn skip_void(input: &[u8]) -> EbmlResult<&[u8]> {
-    pair(verify(vid, |val| *val == 0xEC), elem_size)(input)
-        .and_then(|(i, (_, size))| take(size)(i))
+    pair(verify(vid, |val| *val == 0xEC), elem_size)(input).and_then(|(i, (_, size))| take(size)(i))
 }
 
 const CRC: Crc<u32> = Crc::<u32>::new(&Algorithm {

--- a/src/ebml.rs
+++ b/src/ebml.rs
@@ -36,9 +36,9 @@ pub enum Error {
 #[derive(Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum ErrorKind {
-    /// The value of an unsigned integer does not fit into the platform's
-    /// native uint type. This can not happen on 64-bit platforms.
-    UintTooLarge(u64),
+    /// The Element Data Size did not fit within a [usize].
+    /// The current parsing code cannot handle an element of this size.
+    ElementTooLarge,
 
     /// A required value was not found by the parser.
     MissingRequiredValue(u64),
@@ -145,7 +145,7 @@ pub fn elem_size(input: &[u8]) -> EbmlResult<usize> {
     map_res(vint, |u| {
         usize::try_from(u).map_err(|_| {
             log::error!("Element Data Size does not fit into usize");
-            Error::Ebml(ErrorKind::UintTooLarge(0)) // FIXME: better errorkind
+            Error::Ebml(ErrorKind::ElementTooLarge)
         })
     })(input)
 }

--- a/tools/src/matroska_info.rs
+++ b/tools/src/matroska_info.rs
@@ -28,7 +28,7 @@ pub enum InfoError {
     #[error(display = "unexpected element: {}", _0)]
     UnexpectedElement(String),
     #[error(display = "offset {:X?}: got unknown element: {:X?} {:#?}", _0, _1, _2)]
-    UnknownElement(usize, u64, Option<u64>),
+    UnknownElement(usize, u64, Option<usize>),
     #[error(display = "failed parsing: {}", _0)]
     Parse(String),
     #[error(display = "could not read the file: {}", _0)]


### PR DESCRIPTION
Element Sizes are generally VINTs (up to u64), but the `take` combinator, which we use to get the Element data, only accepts `usize` (for good reason).

The `elem_size` helper fn is meant to replace `vint` in places where we know that we're getting the element size. It will do the same thing as before, but immediately convert to `usize` (or error) instead of doing it later via `usize_error`. This makes life easier since we need `usize` for most things anyways, so this saves us some `x as usize` and a bit of boilerplate.