### PR TITLE
Use u32 for Element IDs instead of u64

### DIFF
--- a/src/elements.rs
+++ b/src/elements.rs
@@ -25,11 +25,11 @@ pub enum SegmentElement<'a> {
     Attachments(Attachments),
     Tags(Tags),
     Void(usize),
-    Unknown(u64, Option<usize>),
+    Unknown(u32, Option<usize>),
 }
 
 // https://datatracker.ietf.org/doc/html/draft-lhomme-cellar-matroska-03#section-7.3.3
-pub fn segment(input: &[u8]) -> EbmlResult<(u64, Option<u64>)> {
+pub fn segment(input: &[u8]) -> EbmlResult<(u32, Option<u64>)> {
     pair(verify(vid, |val| *val == 0x18538067), opt(vint))(input)
 }
 

--- a/tools/src/matroska_info.rs
+++ b/tools/src/matroska_info.rs
@@ -28,7 +28,7 @@ pub enum InfoError {
     #[error(display = "unexpected element: {}", _0)]
     UnexpectedElement(String),
     #[error(display = "offset {:X?}: got unknown element: {:X?} {:#?}", _0, _1, _2)]
-    UnknownElement(usize, u64, Option<usize>),
+    UnknownElement(usize, u32, Option<usize>),
     #[error(display = "failed parsing: {}", _0)]
     Parse(String),
     #[error(display = "could not read the file: {}", _0)]


### PR DESCRIPTION
Closes #110. Mostly signature changes. The `vid_size` function broke so I rewrote it. We can now take advantage of the 4-octet maximum, because the first byte with any bit set to one now signals the size of the ID. Also looks like cookie_factory has some new functions and macros that are a bit more ergonomic than the legacy stuff.