### PR TITLE
Introduce `EbmlParsable` trait to make the EBML parsing more ergonomic

### DIFF
--- a/src/demuxer.rs
+++ b/src/demuxer.rs
@@ -15,7 +15,7 @@ use av_format::{
 };
 
 use crate::{
-    ebml::{self, ebml_err, ebml_header, EbmlHeader, ErrorKind},
+    ebml::{self, ebml_err, ebml_header, EbmlHeader, ParseError},
     elements::{
         segment, segment_element, simple_block, Audio, Cluster, Info, SeekHead, SegmentElement,
         TrackEntry, TrackType, Tracks, Video,
@@ -81,23 +81,23 @@ impl MkvDemuxer {
 
             match element {
                 SegmentElement::SeekHead(s) => {
-                    trace!("got seek head: {:#?}", s);
+                    trace!("got seek head: {s:#?}");
                     self.seek_head = if self.seek_head.is_none() {
                         Some(s)
                     } else {
-                        return ebml_err(ErrorKind::DuplicateSegment(0x114D9B74));
+                        return ebml_err(0x114D9B74, ParseError::DuplicateSegment);
                     };
                 }
                 SegmentElement::Info(i) => {
-                    trace!("got info: {:#?}", i);
+                    trace!("got info: {i:#?}");
                     self.info = if self.info.is_none() {
                         Some(i)
                     } else {
-                        return ebml_err(ErrorKind::DuplicateSegment(0x1549A966));
+                        return ebml_err(0x1549A966, ParseError::DuplicateSegment);
                     };
                 }
                 SegmentElement::Tracks(t) => {
-                    trace!("got tracks: {:#?}", t);
+                    trace!("got tracks: {t:#?}");
                     self.tracks = if self.tracks.is_none() {
                         let mut t = t;
 
@@ -111,11 +111,11 @@ impl MkvDemuxer {
 
                         Some(t)
                     } else {
-                        return ebml_err(ErrorKind::DuplicateSegment(0x1654AE6B));
+                        return ebml_err(0x1654AE6B, ParseError::DuplicateSegment);
                     }
                 }
                 el => {
-                    debug!("got element: {:#?}", el);
+                    debug!("got element: {el:#?}");
                 }
             }
 

--- a/src/permutation.rs
+++ b/src/permutation.rs
@@ -92,8 +92,7 @@ macro_rules! permutation_trait_impl(
           let mut err: Option<Error> = None;
 
           // Skip void elements
-          let void_res = crate::ebml::skip_void(input);
-          if let Ok((i,_)) = void_res {
+          if let Ok((i, _)) = crate::ebml::void(input) {
             input = i;
             continue;
           }

--- a/src/serializer/ebml.rs
+++ b/src/serializer/ebml.rs
@@ -480,7 +480,7 @@ mod tests {
         }
         info!("{}", data.to_hex(16));
 
-        let parse_res: EbmlResult<u64> = crate::ebml::ebml_uint(id)(data);
+        let parse_res: EbmlResult<u64> = crate::ebml::uint(id)(data);
         info!("parse_res: {parse_res:?}");
         match parse_res {
             Ok((_rest, o)) => {
@@ -518,7 +518,7 @@ mod tests {
         }
         info!("{}", (data[..]).to_hex(16));
 
-        let parse_res: EbmlResult<u64> = crate::ebml::ebml_uint(id)(&data[..]);
+        let parse_res: EbmlResult<u64> = crate::ebml::uint(id)(&data[..]);
         info!("parse_res: {:?}", parse_res);
         match parse_res {
           Ok((_rest, o)) => {


### PR DESCRIPTION
Okay, this should be the last time I do major changes to the EBML parsing code.

It has taken a while, but after this I feel good in going over the Matroska specification to fix the obvious issues (default values, optional vs. non-optional values). And then I'd like to fix the remuxer and the info tool.