### PR TITLE
SeekID is an EBML ID: `Vec<u8>` -> `u32`

### DIFF
--- a/src/muxer.rs
+++ b/src/muxer.rs
@@ -257,15 +257,15 @@ impl Muxer for MkvMuxer {
         self.write_tracks(&mut tracks)?;
 
         let info_seek = Seek {
-            id: vec![0x15, 0x49, 0xA9, 0x66],
+            id: 0x1549A966,
             position: 0,
         };
         let tracks_seek = Seek {
-            id: vec![0x16, 0x54, 0xAE, 0x6B],
+            id: 0x1654AE6B,
             position: 0,
         };
         let cluster_seek = Seek {
-            id: vec![0x1F, 0x43, 0xB6, 0x75],
+            id: 0x1F43B675,
             position: 0,
         };
         self.seek_head.positions.push(info_seek);

--- a/tools/src/matroska_info.rs
+++ b/tools/src/matroska_info.rs
@@ -132,29 +132,22 @@ fn run(filename: &str) -> Result<(), InfoError> {
                 SegmentElement::SeekHead(s) => {
                     println!("|+ Seek head at {:#0x} size {}", 0x0, b.data().offset(i));
                     for seek in s.positions.iter() {
-                        let _id: u64 = (u64::from(seek.id[0]) << 24)
-                            | (u64::from(seek.id[1]) << 16)
-                            | (u64::from(seek.id[2]) << 8)
-                            | u64::from(seek.id[3]);
-
                         let element_size = seek.size(0x4DBB);
                         let id_size = seek.id.size(0x53AB);
                         let position_size = seek.position.size(0x53AC);
 
                         println!("| + Seek entry size {}", element_size);
 
-                        print!("|  + Seek ID:");
-                        for id in seek.id.iter() {
-                            print!(" {:#0x}", id);
-                        }
+                        // FIXME: Make the formatting similar to mkvinfo again
+                        print!("|  + Seek ID: {:x}", seek.id);
 
-                        let name = match &seek.id[..] {
-                            [0x11, 0x4D, 0x9B, 0x74] => " (KaxSeekHead)",
-                            [0x12, 0x54, 0xC3, 0x67] => " (KaxTags)",
-                            [0x15, 0x49, 0xA9, 0x66] => " (KaxInfo)",
-                            [0x16, 0x54, 0xAE, 0x6B] => " (KaxTracks)",
-                            [0x1C, 0x53, 0xBB, 0x6B] => " (KaxCues)",
-                            [0x1F, 0x43, 0xB6, 0x75] => " (KaxCluster)",
+                        let name = match seek.id {
+                            0x114D9B74 => " (KaxSeekHead)",
+                            0x1254C367 => " (KaxTags)",
+                            0x1549A966 => " (KaxInfo)",
+                            0x1654AE6B => " (KaxTracks)",
+                            0x1C53BB6B => " (KaxCues)",
+                            0x1F43B675 => " (KaxCluster)",
                             _ => "",
                         };
 


### PR DESCRIPTION
Pretty [self-explanatory](https://www.ietf.org/archive/id/draft-ietf-cellar-matroska-16.html#name-seekid-element):

> 5.1.1.1.1 SeekID Element
id / type: 0x53AB / binary
length: 4
path: \Segment\SeekHead\Seek\SeekID
minOccurs / maxOccurs: 1 / 1
definition: The binary EBML ID of a Top-Level Element. 

Since the length is always 4, we can just interpret the bytes as a u32.