### PR TITLE
Rename Timecode to Timestamp

### DIFF
--- a/src/demuxer.rs
+++ b/src/demuxer.rs
@@ -163,7 +163,7 @@ impl Demuxer for MkvDemuxer {
                 Ok((i, element)) => {
                     let seek = SeekFrom::Current(buf.data().offset(i) as i64);
                     if let SegmentElement::Cluster(c) = element {
-                        debug!("got cluster element at timecode: {}", c.timecode);
+                        debug!("got cluster element at timestamp: {}", c.timestamp);
                         let mut packets = c.generate_packets(self.tracks.as_ref().unwrap());
                         self.queue.extend(packets.drain(..));
                         if let Some(event) = self.queue.pop_front() {
@@ -233,7 +233,7 @@ fn track_entry_media_kind(t: &TrackEntry) -> Option<MediaKind> {
 }
 
 pub fn track_to_stream(info: &Info, t: &TrackEntry) -> Stream {
-    let num = (t.track_timecode_scale * info.timecode_scale as f64) as i64;
+    let num = (t.track_timestamp_scale * info.timestamp_scale as f64) as i64;
 
     Stream {
         id: t.track_uid as isize,
@@ -265,7 +265,7 @@ impl<'a> Cluster<'a> {
                     let packet = Packet {
                         data: i.into(),
                         t: TimeInfo {
-                            pts: Some(i64::from(block.timecode)),
+                            pts: Some(i64::from(block.timestamp)),
                             dts: None,
                             duration: None,
                             timebase: None,

--- a/src/muxer.rs
+++ b/src/muxer.rs
@@ -31,7 +31,7 @@ pub struct MkvMuxer {
     tracks: Option<Tracks>,
     blocks: Vec<Vec<u8>>,
     blocks_len: usize,
-    timecode: Option<u64>,
+    timestamp: Option<u64>,
 }
 
 impl MkvMuxer {
@@ -53,7 +53,7 @@ impl MkvMuxer {
             tracks: None,
             blocks: Vec::new(),
             blocks_len: 0,
-            timecode: None,
+            timestamp: None,
         }
     }
 
@@ -75,7 +75,7 @@ impl MkvMuxer {
             tracks: None,
             blocks: Vec::new(),
             blocks_len: 0,
-            timecode: None,
+            timestamp: None,
         }
     }
 
@@ -296,7 +296,7 @@ impl Muxer for MkvMuxer {
 
         let s = SimpleBlock {
             track_number: pkt.stream_index as u64 + 1,
-            timecode: pkt.t.pts.or(pkt.t.dts).unwrap_or(0) as i16,
+            timestamp: pkt.t.pts.or(pkt.t.dts).unwrap_or(0) as i16,
             keyframe: pkt.is_key,
             invisible: false,
             lacing: Lacing::None,
@@ -334,7 +334,7 @@ impl Muxer for MkvMuxer {
         self.blocks.push(v);
         self.blocks_len += len;
 
-        self.timecode = if self.timecode.is_none() {
+        self.timestamp = if self.timestamp.is_none() {
             Some(pkt.t.pts.or(pkt.t.dts).unwrap_or(0) as u64)
         } else {
             return Err(Error::InvalidData);
@@ -345,7 +345,7 @@ impl Muxer for MkvMuxer {
                 let simple_blocks: Vec<&[u8]> = self.blocks.iter().map(|v| &v[..]).collect();
 
                 let cluster = Cluster {
-                    timecode: self.timecode.take().unwrap(),
+                    timestamp: self.timestamp.take().unwrap(),
                     silent_tracks: None,
                     position: None,
                     prev_size: None,
@@ -397,7 +397,7 @@ impl Muxer for MkvMuxer {
             let simple_blocks: Vec<&[u8]> = self.blocks.iter().map(|v| &v[..]).collect();
 
             let cluster = Cluster {
-                timecode: self.timecode.take().unwrap(),
+                timestamp: self.timestamp.take().unwrap(),
                 silent_tracks: None,
                 position: None,
                 prev_size: None,
@@ -447,7 +447,7 @@ impl Muxer for MkvMuxer {
             muxing_app: String::from("rust-av"),
             writing_app: String::from("rust-av"),
             duration: info.duration.map(|d| d as f64),
-            timecode_scale: 1000000,
+            timestamp_scale: 1000000,
             ..Default::default()
         });
 

--- a/src/serializer/elements.rs
+++ b/src/serializer/elements.rs
@@ -63,7 +63,7 @@ impl EbmlSize for Info {
       + self.next_uid.size(0x3EB923) + self.next_filename.size(0x3E83BB)
       //FIXME: chapter translate
       + self.segment_family.size(0x4444)
-      + self.timecode_scale.size(0x2AD7B1) + self.duration.size(0x4489)
+      + self.timestamp_scale.size(0x2AD7B1) + self.duration.size(0x4489)
       + self.date_utc.size(0x4461) + self.title.size(0x7BA9)
       + self.muxing_app.size(0x4D80) + self.writing_app.size(0x5741)
     }
@@ -85,7 +85,7 @@ pub(crate) fn gen_info<'a, 'b>(
                 gen_opt(i.next_uid.as_ref(), |v| gen_ebml_binary(0x3EB923, v)),
                 gen_opt(i.next_filename.as_ref(), |v| gen_ebml_str(0x3E83BB, v)),
                 gen_opt(i.segment_family.as_ref(), |v| gen_ebml_binary(0x4444, v)),
-                gen_ebml_uint(0x2AD7B1, i.timecode_scale),
+                gen_ebml_uint(0x2AD7B1, i.timestamp_scale),
                 gen_opt(i.duration.as_ref(), |v| gen_f64(0x4489, *v)),
                 gen_opt(i.date_utc.as_ref(), |v| gen_ebml_binary(0x4461, v)),
                 gen_opt(i.title.as_ref(), |v| gen_ebml_str(0x7BA9, v)),
@@ -130,7 +130,7 @@ impl EbmlSize for TrackEntry {
             + self.max_cache.size(0x6DF8)
             + self.default_duration.size(0x23E383)
             + self.default_decoded_field_duration.size(0x234E7A)
-            + self.track_timecode_scale.size(0x23314F)
+            + self.track_timestamp_scale.size(0x23314F)
             + self.track_offset.size(0x537F)
             + self.max_block_addition_id.size(0x55EE)
             + self.name.size(0x536E)
@@ -181,7 +181,7 @@ fn gen_track_entry<'a, 'b>(
                 gen_opt_copy(t.default_decoded_field_duration, |v| {
                     gen_ebml_uint(0x234E7A, v)
                 }),
-                gen_f64(0x23314F, t.track_timecode_scale), // FIXME: don't serialize if default
+                gen_f64(0x23314F, t.track_timestamp_scale), // FIXME: don't serialize if default
                 gen_opt_copy(t.track_offset, |v| gen_ebml_int(0x537F, v)),
                 gen_opt_copy(t.max_block_addition_id, |v| gen_ebml_uint(0x55EE, v)),
                 gen_opt(t.name.as_ref(), |v| gen_ebml_str(0x536E, v)),
@@ -430,7 +430,7 @@ fn gen_track_entry_video_projection<'a, 'b>(
 
 impl<'a> EbmlSize for Cluster<'a> {
     fn capacity(&self) -> usize {
-        self.timecode.size(0xE7) + self.silent_tracks.size(0x5854) + self.position.size(0xA7) +
+        self.timestamp.size(0xE7) + self.silent_tracks.size(0x5854) + self.position.size(0xA7) +
       self.prev_size.size(0xAB) + self.simple_block.size(0xA3) +
       // TODO: implement for BlockGroup
       // self.block_group.size(0xA0) +
@@ -447,7 +447,7 @@ pub(crate) fn gen_cluster<'a, 'b>(
             0x1F43B675,
             byte_capacity,
             tuple((
-                gen_ebml_uint(0xE7, c.timecode),
+                gen_ebml_uint(0xE7, c.timestamp),
                 gen_opt(c.silent_tracks.as_ref(), gen_silent_tracks),
                 gen_opt_copy(c.position, |v| gen_ebml_uint(0xA7, v)),
                 gen_opt_copy(c.prev_size, |v| gen_ebml_uint(0xAB, v)),
@@ -505,7 +505,7 @@ pub(crate) fn gen_simple_block_header<'a, 'b>(
         }
 
         set_be_u8(
-            tuple((gen_vint(s.track_number), |i| set_be_i16(i, s.timecode)))(input)?,
+            tuple((gen_vint(s.track_number), |i| set_be_i16(i, s.timestamp)))(input)?,
             flags,
         )
     }

--- a/tools/src/matroska_info.rs
+++ b/tools/src/matroska_info.rs
@@ -170,9 +170,9 @@ fn run(filename: &str) -> Result<(), InfoError> {
                         "| + Segment UID: {}",
                         i.segment_uid.map(format_uid).unwrap_or(String::new())
                     );
-                    println!("| + Timestamp scale: {}", i.timecode_scale);
+                    println!("| + Timestamp scale: {}", i.timestamp_scale);
                     if let Some(f) = i.duration {
-                        let nanos = f * i.timecode_scale as f64;
+                        let nanos = f * i.timestamp_scale as f64;
                         let d = Duration::from_nanos(nanos.round() as u64);
                         println!("| + Duration: {}", format_duration(d));
                     }
@@ -294,7 +294,7 @@ fn run(filename: &str) -> Result<(), InfoError> {
                 }
                 SegmentElement::Cluster(c) => {
                     println!("|+ Cluster");
-                    println!("|+   Timecode: {}", c.timecode);
+                    println!("|+   Timestamp: {}", c.timestamp);
                     println!("|+   Silent_tracks: {:?}", c.silent_tracks);
                     println!("|+   Position: {:?}", c.position);
                     println!("|+   Prev size: {:?}", c.prev_size);


### PR DESCRIPTION
Timecode is the old, "mistaken" ([their words](https://www.ietf.org/archive/id/draft-ietf-cellar-matroska-16.html#name-timestamps), not mine) name for what is now the Timestamp.