### PR TITLE
Rework Permutation for better ergonomics & to skip unknown Elements

### DIFF
--- a/src/ebml.rs
+++ b/src/ebml.rs
@@ -321,6 +321,14 @@ pub fn void(input: &[u8]) -> EbmlResult<&[u8]> {
     binary_ref(0xEC)(input)
 }
 
+/// Consumes an entire Master Element, and returns the ID if successful.
+pub fn skip_master(input: &[u8]) -> EbmlResult<u32> {
+    let (i, (id, size, crc)) = tuple((vid, elem_size, crc))(input)?;
+    let size = if crc.is_some() { size - 6 } else { size };
+    checksum(crc, take(size))(i)?;
+    Ok((i, id))
+}
+
 const CRC: Crc<u32> = Crc::<u32>::new(&Algorithm {
     init: 0xFFFFFFFF,
     ..crc::CRC_32_ISO_HDLC

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -1,6 +1,6 @@
 use nom::{
     bytes::streaming::take,
-    combinator::{complete, cond, map, map_opt, opt, verify},
+    combinator::{complete, cond, map, map_opt, opt},
     multi::{many0, many1},
     number::streaming::{be_i16, be_u8},
     sequence::{pair, tuple},
@@ -9,8 +9,8 @@ use nom::{
 pub use uuid::Uuid;
 
 use crate::ebml::{
-    binary, binary_exact, binary_ref, checksum, crc, elem_size, float, float_or, int, master,
-    skip_void, str, uint, uuid, vid, vint, EbmlResult,
+    binary, binary_exact, binary_ref, check_id, checksum, crc, elem_size, float, float_or, int,
+    master, skip_void, str, uint, uuid, vid, vint, EbmlResult,
 };
 use crate::permutation::matroska_permutation;
 
@@ -30,7 +30,7 @@ pub enum SegmentElement<'a> {
 
 // https://datatracker.ietf.org/doc/html/draft-lhomme-cellar-matroska-03#section-7.3.3
 pub fn segment(input: &[u8]) -> EbmlResult<(u32, Option<u64>)> {
-    pair(verify(vid, |val| *val == 0x18538067), opt(vint))(input)
+    pair(check_id(0x18538067), opt(vint))(input)
 }
 
 pub fn sub_element<'a, O1, G>(second: G) -> impl Fn(&'a [u8]) -> EbmlResult<'a, O1>

--- a/src/permutation.rs
+++ b/src/permutation.rs
@@ -100,9 +100,8 @@ macro_rules! permutation_trait_impl(
 
           // Have all parsers (including void) failed?
           if l == input.len() {
-            // If the error is ErrorKind::Verify, our problem is an unknown ID.
-            // In that case, skip the entire Element with a warning.
-            if let Some(Error::Nom(ErrorKind::Verify)) = err {
+            // Skip unknown Element if possible.
+            if let Some(Error::Ebml(_, crate::ebml::ParseError::UnknownID)) = err {
               if let Ok((i, id)) = crate::ebml::skip_master(input) {
                 log::warn!("Skipped unknown Element 0x{id:X}");
                 input = i;


### PR DESCRIPTION
This addresses #117.

1. Permutation now doesn't return a tuple of `(Option<T1>, Option<T2>, ...)` but just `(T1, T2, ...)`. `Option<T>` is now only used if the Element is explicitly optional (for example, by using `opt(uint(id))` instead of just `uint(id)`). This means no more `value_error` helper function, because `fn permutation` now handles "unwrapping".
2. Introduce `check_id` function to replace `verify(vid, |val| *val == id)` that we had in a few places. Except the error is now `Ebml(id, ParseError::MissingElement)`.
3. Override `<ebml::Error as ParseError>::or` to avoid having the `Complete` ErrorKind shadow the real error.
4. Introduce `skip_master` function and use it to skip Elements with unknown IDs (with warn log message)

Overall, this improves readability (explicit `opt` + "automatic" error handling for required elements) and allows skipping unknown Elements. 