### PR TITLE
Replace log macros in tests with `println!`

### DIFF
--- a/src/demuxer.rs
+++ b/src/demuxer.rs
@@ -321,7 +321,6 @@ pub const MKV_DESC: &dyn Descriptor<OutputDemuxer = MkvDemuxer> = &Des {
 mod tests {
     use std::io::Cursor;
 
-    use log::info;
     use nom::Offset;
 
     use av_format::{buffer::*, demuxer::Context};
@@ -335,17 +334,17 @@ mod tests {
         let mut demuxer = MkvDemuxer::new();
 
         let res = demuxer.parse_until_tracks(webm);
-        info!("got parsing res: {:?}", res);
+        println!("got parsing res: {res:?}");
         match res {
             Ok((i, _)) => {
-                info!("offset: {} bytes", webm.offset(i));
+                println!("offset: {} bytes", webm.offset(i));
             }
             e => {
-                info!("could not parse: {:?}", e);
+                println!("could not parse: {e:?}");
             }
         }
 
-        info!("demuxer: {:#?}", demuxer);
+        println!("demuxer: {demuxer:#?}");
     }
 
     #[test]
@@ -355,10 +354,10 @@ mod tests {
         for n in 100..2000 {
             let res = demuxer.parse_until_tracks(&webm[0..n]);
             match res {
-                Ok(_) => info!("Size {} ok", n),
-                Err(Err::Incomplete(needed)) => info!("Incomplete {} needs {:?}", n, needed),
+                Ok(_) => println!("Size {n} ok"),
+                Err(Err::Incomplete(needed)) => println!("Incomplete {n} needs {needed:?}"),
                 Err(e) => {
-                    panic!("Error at size {}: {:?}", n, e);
+                    panic!("Error at size {n}: {e:?}");
                 }
             }
         }
@@ -371,7 +370,7 @@ mod tests {
         println!("{:?}", context.read_headers().unwrap());
 
         while let Ok(event) = context.read_event() {
-            println!("event: {:?}", event);
+            println!("event: {event:?}");
             if let Event::Eof = event {
                 break;
             }

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -1026,7 +1026,6 @@ pub struct Tags {}
 mod tests {
     use std::cmp::min;
 
-    use log::debug;
     use nom::{HexDisplay, Offset};
 
     use super::*;
@@ -1037,12 +1036,12 @@ mod tests {
     #[test]
     fn mkv_segment_root() {
         let res = segment(&mkv[47..100]);
-        debug!("{:?}", res);
+        println!("{res:?}");
 
         if let Ok((i, _)) = res {
-            debug!("consumed {} bytes after header", (mkv[47..]).offset(i));
+            println!("consumed {} bytes after header", (mkv[47..]).offset(i));
         } else {
-            panic!("res: {:?}", res);
+            panic!("res: {res:?}");
         }
     }
 
@@ -1058,13 +1057,12 @@ mod tests {
                     let new_index = mkv.offset(i);
                     match o {
                         SegmentElement::Unknown(id, size) => {
-                            debug!(
-                                "[{} -> {}] Unknown {{ id: 0x{:x}, size: {:?} }}",
-                                index, new_index, id, size
+                            println!(
+                                "[{index} -> {new_index}] Unknown {{ id: 0x{id:x}, size: {size:?} }}",
                             );
                         }
                         o => {
-                            debug!("[{} -> {}] {:#?}", index, new_index, o);
+                            println!("[{index} -> {new_index}] {o:#?}");
                         }
                     };
 
@@ -1072,10 +1070,8 @@ mod tests {
                 }
                 e => {
                     let max_index = min(mkv.len(), index + 200);
-                    debug!(
-                        "[{}] {:#?}:\n{}",
-                        index,
-                        e,
+                    println!(
+                        "[{index}] {e:#?}:\n{}",
                         (mkv[index..max_index]).to_hex(16)
                     );
                     break;
@@ -1087,12 +1083,12 @@ mod tests {
     #[test]
     fn webm_segment_root() {
         let res = segment(&webm[40..100]);
-        debug!("{:?}", res);
+        println!("{res:?}");
 
         if let Ok((i, _)) = res {
-            debug!("consumed {} bytes after header", (webm[40..]).offset(i));
+            println!("consumed {} bytes after header", (webm[40..]).offset(i));
         } else {
-            panic!("res: {:?}", res);
+            panic!("res: {res:?}");
         }
     }
 
@@ -1108,13 +1104,12 @@ mod tests {
                     let new_index = webm.offset(i);
                     match o {
                         SegmentElement::Unknown(id, size) => {
-                            debug!(
-                                "[{} -> {}] Unknown {{ id: 0x{:x}, size: {:?} }}",
-                                index, new_index, id, size
+                            println!(
+                                "[{index} -> {new_index}] Unknown {{ id: 0x{id:x}, size: {size:?} }}"
                             );
                         }
                         o => {
-                            debug!("[{} -> {}] {:#?}", index, new_index, o);
+                            println!("[{index} -> {new_index}] {o:#?}");
                         }
                     };
 
@@ -1122,10 +1117,8 @@ mod tests {
                 }
                 e => {
                     let max_index = min(webm.len(), index + 200);
-                    debug!(
-                        "[{}] {:#?}:\n{}",
-                        index,
-                        e,
+                    println!(
+                        "[{index}] {e:#?}:\n{}",
                         (webm[index..max_index]).to_hex(16)
                     );
                     break;

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -1070,10 +1070,7 @@ mod tests {
                 }
                 e => {
                     let max_index = min(mkv.len(), index + 200);
-                    println!(
-                        "[{index}] {e:#?}:\n{}",
-                        (mkv[index..max_index]).to_hex(16)
-                    );
+                    println!("[{index}] {e:#?}:\n{}", (mkv[index..max_index]).to_hex(16));
                     break;
                 }
             }
@@ -1117,10 +1114,7 @@ mod tests {
                 }
                 e => {
                     let max_index = min(webm.len(), index + 200);
-                    println!(
-                        "[{index}] {e:#?}:\n{}",
-                        (webm[index..max_index]).to_hex(16)
-                    );
+                    println!("[{index}] {e:#?}:\n{}", (webm[index..max_index]).to_hex(16));
                     break;
                 }
             }

--- a/src/serializer/ebml.rs
+++ b/src/serializer/ebml.rs
@@ -376,7 +376,6 @@ impl EbmlSize for uuid::Uuid {
 #[cfg(test)]
 mod tests {
     use cookie_factory::gen::set_be_u64;
-    use log::{info, trace};
     use nom::HexDisplay;
     use quickcheck::quickcheck;
 
@@ -399,29 +398,29 @@ mod tests {
     }
 
     fn test_vint_serializer(i: u64) -> bool {
-        info!("testing for {}", i);
+        println!("testing for {i}");
 
         let mut data = [0u8; 10];
         {
             let gen_res = gen_vint(i)((&mut data[..], 0));
             if let Err(e) = gen_res {
-                trace!("gen_res is error: {:?}", e);
-                trace!("Large id value: {:?}", i);
+                println!("gen_res is error: {e:?}");
+                println!("Large id value: {i:?}");
                 // Do not fail if quickcheck generated data is too large
                 return i >= ALLOWED_ID_VALUES;
             }
-            info!("gen_res: {:?}", gen_res);
+            println!("gen_res: {gen_res:?}");
         }
-        info!("{}", (data[..]).to_hex(16));
+        println!("{}", (data[..]).to_hex(16));
 
         let parse_res = crate::ebml::vint(&data[..]);
-        info!("parse_res: {:?}", parse_res);
+        println!("parse_res: {parse_res:?}");
         match parse_res {
             Ok((_rest, o)) => {
                 assert_eq!(i, o);
                 true
             }
-            e => panic!("{}", format!("parse error: {:?}", e)),
+            e => panic!("parse error: {e:?}"),
         }
     }
 
@@ -441,24 +440,24 @@ mod tests {
     }
 
     fn test_vid_serializer(id: u32) -> bool {
-        info!("\ntesting for id={}", id);
+        println!("\ntesting for id={id}");
 
         let mut data = [0u8; 10];
         {
             let gen_res = gen_vid(id)((&mut data[..], 0));
-            info!("gen_res: {:?}", gen_res);
+            println!("gen_res: {gen_res:?}");
         }
-        info!("{}", (data[..]).to_hex(16));
+        println!("{}", (data[..]).to_hex(16));
 
         let parse_res = crate::ebml::vid(&data[..]);
-        info!("parse_res: {:?}", parse_res);
+        println!("parse_res: {parse_res:?}");
         match parse_res {
             Ok((_rest, o)) => {
-                info!("id={:08b}, parsed={:08b}", id, o);
+                println!("id={id:08b}, parsed={o:08b}");
                 assert_eq!(id, o);
                 true
             }
-            e => panic!("{}", format!("parse error: {:?}", e)),
+            e => panic!("parse error: {e:?}"),
         }
     }
 
@@ -471,17 +470,17 @@ mod tests {
 
     fn test_ebml_u64_serializer(num: u64) -> bool {
         let id = 0x9F;
-        info!("\ntesting for id={id}, num={num}");
+        println!("\ntesting for id={id}, num={num}");
 
         let data = &mut [0u8; 100];
         {
             let (_, written) = gen_u64(id, num)((data, 0)).unwrap();
-            info!("written: {written:?}");
+            println!("written: {written:?}");
         }
-        info!("{}", data.to_hex(16));
+        println!("{}", data.to_hex(16));
 
         let parse_res: EbmlResult<u64> = crate::ebml::uint(id)(data);
-        info!("parse_res: {parse_res:?}");
+        println!("parse_res: {parse_res:?}");
         match parse_res {
             Ok((_rest, o)) => {
                 assert_eq!(num, o);
@@ -509,23 +508,23 @@ mod tests {
     quickcheck! {
       fn test_ebml_u8(num: u8) -> bool {
         let id = 0x9F;
-        info!("testing for id={}, num={}", id, num);
+        println!("testing for id={id}, num={num}");
 
         let mut data = [0u8; 100];
         {
           let gen_res = gen_u8(id, num)((&mut data[..], 0));
-          info!("gen_res: {:?}", gen_res);
+          println!("gen_res: {gen_res:?}");
         }
-        info!("{}", (data[..]).to_hex(16));
+        println!("{}", (data[..]).to_hex(16));
 
         let parse_res: EbmlResult<u64> = crate::ebml::uint(id)(&data[..]);
-        info!("parse_res: {:?}", parse_res);
+        println!("parse_res: {parse_res:?}");
         match parse_res {
           Ok((_rest, o)) => {
             assert_eq!(num as u64, o);
             true
           },
-          e => panic!("{}", format!("parse error: {:?}", e)),
+          e => panic!("parse error: {e:?}"),
         }
       }
     }
@@ -543,11 +542,11 @@ mod tests {
           doc_type_read_version: doc_type_read_version as u32,
         };
 
-        info!("will serialize: {:#?}", header);
+        println!("will serialize: {header:#?}");
         let mut data = [0u8; 100];
         {
           let gen_res = gen_ebml_header(&header)((&mut data[..], 0));
-          info!("gen_res: {:?}", gen_res);
+          println!("gen_res: {gen_res:?}");
           // Do not fail if quickcheck generated data is too large
           match gen_res {
             Err(GenError::BufferTooSmall(_)) => return true,
@@ -556,15 +555,15 @@ mod tests {
           }
         }
 
-        info!("{}", (data[..]).to_hex(16));
+        println!("{}", (data[..]).to_hex(16));
         let parse_res = crate::ebml::ebml_header(&data[..]);
-        info!("parse_res: {:?}", parse_res);
+        println!("parse_res: {parse_res:?}");
         match parse_res {
           Ok((_rest, h)) => {
             assert_eq!(header, h);
             true
           },
-          e => panic!("{}", format!("parse error: {:?}", e)),
+          e => panic!("parse error: {e:?}"),
         }
       }
     }

--- a/src/serializer/elements.rs
+++ b/src/serializer/elements.rs
@@ -555,7 +555,6 @@ fn gen_fixed_size_laced_frames<'a>(
 
 #[cfg(test)]
 mod tests {
-    use log::trace;
     use quickcheck::{quickcheck, Arbitrary, Gen, TestResult};
 
     use crate::elements::SegmentElement;
@@ -572,14 +571,14 @@ mod tests {
     }
 
     fn test_seek_head_serializer(seeks: Vec<Seek>) -> bool {
-        trace!("testing for {seeks:?}");
+        println!("testing for {seeks:?}");
 
         for seek in seeks.iter() {
-            trace!("id: {:x}", seek.id);
+            println!("id: {:x}", seek.id);
         }
 
         let capacity = (12 + 100) * seeks.len(); // (fields + padding) * len
-        trace!("defining capacity as {capacity}");
+        println!("defining capacity as {capacity}");
 
         let mut data = vec![0; capacity];
 
@@ -588,15 +587,15 @@ mod tests {
         };
 
         let gen_res = gen_seek_head(&seek_head)((&mut data[..], 0));
-        trace!("gen_res: {gen_res:?}");
+        println!("gen_res: {gen_res:?}");
         if let Err(e) = gen_res {
-            trace!("gen_res is error: {e:?}");
+            println!("gen_res is error: {e:?}");
             // Do not fail if quickcheck generated data is too large
             return true;
         }
 
         let parse_res = crate::elements::segment_element(&data[..]);
-        trace!("parse_res: {parse_res:?}");
+        println!("parse_res: {parse_res:?}");
         match parse_res {
             Ok((_, SegmentElement::SeekHead(o))) => {
                 assert_eq!(seek_head, o);


### PR DESCRIPTION
There's no logger being initialised by the test suite. This means we don't get any log output at all. So it's easier to just `println!` in the tests, to get at least that output to the console.

There's also a good [stackoverflow question](https://stackoverflow.com/questions/67087597/is-it-possible-to-use-rusts-log-info-for-tests) regarding the possibility of getting log output in tests, in case we want to go that way.

Also moved variables into the format string wherever possible.