### PR TITLE
Fix SimpleBlock header struct parse error

### DIFF
--- a/.github/workflows/matroska.yml
+++ b/.github/workflows/matroska.yml
@@ -77,12 +77,12 @@ jobs:
     strategy:
       matrix:
         toolchain:
-         - stable-x86_64-apple-darwin
+         - stable-aarch64-apple-darwin
          - stable-x86_64-unknown-linux-gnu
          - stable-x86_64-pc-windows-msvc
          - stable-i686-pc-windows-msvc
         include:
-         - toolchain: stable-x86_64-apple-darwin
+         - toolchain: stable-aarch64-apple-darwin
            os: macOS-latest
          - toolchain: stable-x86_64-unknown-linux-gnu
            os: ubuntu-latest

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -180,7 +180,7 @@ pub struct SimpleBlock {
 }
 
 fn block_flags(data: u8) -> Option<BlockFlags> {
-    let lacing_data = ((data << 6) >> 6) >> 5;
+    let lacing_data = ((data << 5) >> 5) >> 1;
     let lacing = match lacing_data {
         0 => Lacing::None,
         1 => Lacing::Xiph,
@@ -190,10 +190,10 @@ fn block_flags(data: u8) -> Option<BlockFlags> {
     };
 
     Some(BlockFlags {
-        keyframe: (data & 1) != 0,
-        invisible: (data & (1 << 4)) != 0,
+        keyframe: (data & (1 << 7)) != 0,
+        invisible: (data & (1 << 3)) != 0,
         lacing,
-        discardable: (data & (1 << 7)) != 0,
+        discardable: (data & 1) != 0,
     })
 }
 

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -496,6 +496,52 @@ mod tests {
     const webm: &[u8] = include_bytes!("../assets/big-buck-bunny_trailer.webm");
 
     #[test]
+    fn block_flags() {
+        let test = [
+            (
+                0b1000_1011,
+                Some(BlockFlags {
+                    keyframe: true,
+                    invisible: true,
+                    lacing: Lacing::Xiph,
+                    discardable: true,
+                }),
+            ),
+            (
+                0b0000_0000,
+                Some(BlockFlags {
+                    keyframe: false,
+                    invisible: false,
+                    lacing: Lacing::None,
+                    discardable: false,
+                }),
+            ),
+            (
+                0b0000_0110,
+                Some(BlockFlags {
+                    keyframe: false,
+                    invisible: false,
+                    lacing: Lacing::EBML,
+                    discardable: false,
+                }),
+            ),
+            (
+                0b0000_0101,
+                Some(BlockFlags {
+                    keyframe: false,
+                    invisible: false,
+                    lacing: Lacing::FixedSize,
+                    discardable: true,
+                }),
+            ),
+        ];
+
+        for (data, flags) in test {
+            assert_eq!(super::block_flags(data), flags);
+        }
+    }
+
+    #[test]
     fn mkv_segment_root() {
         let res = segment(&mkv[47..100]);
         println!("{res:?}");


### PR DESCRIPTION
When I used this library to parse SimpleBlock, I found that the parsed keyframe field value was wrong. After querying the rfc document, I found that the parsing was wrong.

In RFC doc: https://datatracker.ietf.org/doc/rfc9559/
10.2.  SimpleBlock Structure says: Bit 0 is the most significant bit.